### PR TITLE
World exit Condition

### DIFF
--- a/FlingEngine/Core/inc/Engine.h
+++ b/FlingEngine/Core/inc/Engine.h
@@ -13,6 +13,10 @@
 
 namespace Fling
 {
+	/**
+	 * @brief Core engine class of Fling. This is where the core update loop lives 
+	 * along with all startup/shutdown ordering. 
+	 */
 	class FLING_API Engine : public NonCopyable
 	{
 	public:
@@ -23,10 +27,11 @@ namespace Fling
 
 		~Engine() = default;
 
-		/// <summary>
-		/// Run the engine
-		/// </summary>
-		/// <returns>Error code or 0 for success</returns>
+		/**
+		 * @brief Run the engine (Startup, Tick until should stop, and shutodwn)
+		 * 
+		 * @return UINT64 0 for success, otherwise an error has occured
+		 */
 		UINT64 Run();
 
 	private:
@@ -48,5 +53,8 @@ namespace Fling
 
         int m_CmdLineArgCount = 0;
         char** m_CmdLineArgs = nullptr;
+
+		/** Persistant world object that can be used to load levels, entities, etc */
+		World* m_World = nullptr;
 	};
 }	// namespace Fling

--- a/FlingEngine/Core/src/Engine.cpp
+++ b/FlingEngine/Core/src/Engine.cpp
@@ -78,7 +78,12 @@ namespace Fling
 			Renderer.Tick();
 
 			m_World->Update(DeltaTime);
-			
+			if(m_World->ShouldQuit())
+			{
+				F_LOG_TRACE("World should quit! Exiting engine loop...");
+				break;
+			}
+
 			Renderer.DrawFrame();
 
             // Update timing

--- a/FlingEngine/Core/src/Engine.cpp
+++ b/FlingEngine/Core/src/Engine.cpp
@@ -57,7 +57,7 @@ namespace Fling
 
 		ComponentManager::Get().Init();
 
-		World::Get().Init();
+		m_World = new World();
 	}
 
 	void Engine::Tick()
@@ -68,7 +68,8 @@ namespace Fling
 
         float DeltaTime = FallbackDeltaTime;
 		
-		World& World = World::Get();
+		assert(m_World);		// We HAVE to have a world
+		
 		Renderer& Renderer = Renderer::Get();
 		Timing& Timing = Timing::Get();
 
@@ -76,7 +77,7 @@ namespace Fling
 		{
 			Renderer.Tick();
 
-			World.Update(DeltaTime);
+			m_World->Update(DeltaTime);
 			
 			Renderer.DrawFrame();
 
@@ -99,7 +100,13 @@ namespace Fling
 	void Engine::Shutdown()
 	{
 		ComponentManager::Get().Shutdown();
-		World::Get().Shutdown();
+		
+		if(m_World)
+		{
+			m_World->Shutdown();
+			delete m_World;
+			m_World = nullptr;
+		}
 		
 		// Cleanup any resources
 		Input::Shutdown();

--- a/FlingEngine/Gameplay/inc/Level.h
+++ b/FlingEngine/Gameplay/inc/Level.h
@@ -61,6 +61,6 @@ namespace Fling
         void PostLoad();
 
         /** The owning work that this level exists in */
-        World* m_OwningWorld;
+        World* m_OwningWorld = nullptr;
     };
 }   // namespace Fling

--- a/FlingEngine/Gameplay/inc/Level.h
+++ b/FlingEngine/Gameplay/inc/Level.h
@@ -6,6 +6,8 @@
 
 namespace Fling
 {
+    class World;
+
     /**
      * @brief   A level contains active objects and provides the environment
      *          for the player. You should only load a level through the world. 
@@ -17,7 +19,7 @@ namespace Fling
 		* Loads this level based on the given file name. 
 		* @param t_LevelFile		The path to the level file (should be a full path, NOT relative to assets dir)
 		*/
-        explicit Level(const std::string& t_LevelFile);
+        explicit Level(const std::string& t_LevelFile, World* t_OwningWorld);
         ~Level();
 
         /**
@@ -32,6 +34,13 @@ namespace Fling
          * @brief Unload the current level and all actors inside of it
          */
         void Unload();
+
+        /**
+         * @brief Get the Owning World object of this level. 
+         * 
+         * @return World* 
+         */
+        World* GetOwningWorld() const { return m_OwningWorld; }
 
     private:
 
@@ -50,5 +59,8 @@ namespace Fling
          * @brief Any behavior that needs to happen after the level has been fully loaded.
          */
         void PostLoad();
+
+        /** The owning work that this level exists in */
+        World* m_OwningWorld;
     };
 }   // namespace Fling

--- a/FlingEngine/Gameplay/inc/World.h
+++ b/FlingEngine/Gameplay/inc/World.h
@@ -43,11 +43,21 @@ namespace Fling
 		*/
         void LoadLevel(const std::string& t_LevelPath);
 
+		/**
+		 * @brief Check if the world wants to exit the program. 
+		 * @see Engine::Tick 
+		 * 
+		 * @return True if the world has signlaed for exit
+		 */
+		FORCEINLINE bool ShouldQuit() const { return m_ShouldQuit; }
+
     private:
 
 		// #TODO: Pointer to the player!
 
         /** Currently active levels in the world */
         std::vector<std::unique_ptr<Level>> m_ActiveLevels;
+
+		UINT8 m_ShouldQuit = false;
     };
 } // namespace Fling

--- a/FlingEngine/Gameplay/inc/World.h
+++ b/FlingEngine/Gameplay/inc/World.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Singleton.hpp"
+#include "NonCopyable.hpp"
 #include "Level.h"
 
 #include <string>
@@ -14,15 +14,16 @@ namespace Fling
 	* instance at any given time. 
 	* @see Level
 	*/
-    class World : public Singleton<World>
+    class World : public NonCopyable
     {
     public: 
 		/**
 		* @brief	Initializes the world. Loads the StartLevel that is specified in the config.  
+		* @note		Keep explict Init and Shutdown functions to make the startup order more readable
 		*/
-        virtual void Init() override;
+        void Init();
 
-        virtual void Shutdown() override;
+        void Shutdown();
 
 		/**
 		* Called before the first Update tick on the world. 

--- a/FlingEngine/Gameplay/src/Level.cpp
+++ b/FlingEngine/Gameplay/src/Level.cpp
@@ -2,11 +2,13 @@
 #include "Level.h"
 #include "ResourceManager.h"
 #include "JsonFile.h"
+#include "World.h"
 
 namespace Fling
 {
-    Level::Level(const std::string& t_LevelFile)
+    Level::Level(const std::string& t_LevelFile, World* t_OwningWorld)
         : m_LevelFileName(t_LevelFile)
+        , m_OwningWorld(t_OwningWorld)
     {
 		// Load in a file resource based on this file
         LoadLevel();

--- a/FlingEngine/Gameplay/src/World.cpp
+++ b/FlingEngine/Gameplay/src/World.cpp
@@ -45,6 +45,6 @@ namespace Fling
 
 		// #TODO: Unload the current level? Depends on how we want to do async loading in the future
 
-		m_ActiveLevels.emplace_back(std::move(std::make_unique<Level>(t_LevelPath)));
+		m_ActiveLevels.emplace_back(std::move(std::make_unique<Level>(t_LevelPath, this)));
     }
 } // namespace Fling

--- a/FlingEngine/Gameplay/src/World.cpp
+++ b/FlingEngine/Gameplay/src/World.cpp
@@ -29,6 +29,8 @@ namespace Fling
 
     void World::Update(float t_DeltaTime)
     {
+		m_ShouldQuit = (m_ShouldQuit ? m_ShouldQuit : Input::IsKeyDown(KeyNames::FL_KEY_ESCAPE));
+
 		for (const std::unique_ptr<Level>& Level : m_ActiveLevels)
 		{
 			if (Level)


### PR DESCRIPTION
Add a `ShouldQuit` check on the world and `Engine` so that we can exit the engine from user input/other world events

Depends on #36 

See #31 