### PR TITLE
Add input delegate mappings 

### DIFF
--- a/FlingEngine/Core/inc/Input/Input.h
+++ b/FlingEngine/Core/inc/Input/Input.h
@@ -2,6 +2,8 @@
 
 #include "NonCopyable.hpp"
 #include "Input/Key.h"
+#include <entt/signal/delegate.hpp>
+#include <entt/signal/sigh.hpp>
 
 namespace Fling
 {
@@ -45,11 +47,17 @@ namespace Fling
 		static bool IsMouseButtonPressed(const std::string& t_KeyName) { return m_Instace->IsMouseButtonPressedImpl(t_KeyName); }
 		static bool IsMouseDown(const std::string& t_KeyName) { return m_Instace->IsMouseDownImpl(t_KeyName); }
 
-
 		/**
 		 * Get the current mouse position in screen space
 		 */
 		static MousePos GetMousePos() { return m_Instace->GetMousePosImpl(); }
+		
+		template<auto Candidate, typename Type>
+		static void BindKeyPress(const std::string& t_KeyName, Type& t_Instance)
+		{
+			entt::delegate<void()> delegate{};
+			delegate.connect<Candidate>(t_Instance);
+		}
 
 		typedef std::map<std::string, Fling::Key> KeyMap;
 		typedef std::pair<std::string, Fling::Key> KeyPair;

--- a/FlingEngine/Core/inc/Input/Input.h
+++ b/FlingEngine/Core/inc/Input/Input.h
@@ -59,13 +59,20 @@ namespace Fling
 			delegate.connect<Candidate>(t_Instance);
 		}
 
+		/** Input Key mappings */
 		typedef std::map<std::string, Fling::Key> KeyMap;
 		typedef std::pair<std::string, Fling::Key> KeyPair;
+
+		/** Key press delegate mappings */
+		typedef std::map<std::string, entt::delegate<void()>> KeyDownMap;
+		typedef std::pair<std::string, Fling::Key> KeyDownMapPair;
 
 	protected:
 
 		/** The actual key map */
 		static KeyMap m_KeyMap;
+
+		static KeyDownMap m_KeyDownMap;
 
 		/** Created by the implementation class @see WindowInput */
 		static Input* m_Instace;

--- a/FlingEngine/Core/inc/Input/Input.h
+++ b/FlingEngine/Core/inc/Input/Input.h
@@ -52,12 +52,17 @@ namespace Fling
 		 */
 		static MousePos GetMousePos() { return m_Instace->GetMousePosImpl(); }
 		
+		/**
+		 * @brief Bind a callback function to when a key is pressed 
+		 * 
+		 * @tparam Candidate The function that you would like to bind
+		 * @param t_KeyName Key name to bind to 
+		 * @param t_Instance The instance of the object you are binding to
+		 * @see https://github.com/skypjack/entt/wiki/Crash-Course:-events,-signals-and-everything-in-between#delegate
+		 * @see Fling::KeyNames
+		 */
 		template<auto Candidate, typename Type>
-		static void BindKeyPress(const std::string& t_KeyName, Type& t_Instance)
-		{
-			entt::delegate<void()> delegate{};
-			delegate.connect<Candidate>(t_Instance);
-		}
+		static void BindKeyPress(const std::string& t_KeyName, Type& t_Instance);
 
 		/** Input Key mappings */
 		typedef std::map<std::string, Fling::Key> KeyMap;
@@ -65,7 +70,7 @@ namespace Fling
 
 		/** Key press delegate mappings */
 		typedef std::map<std::string, entt::delegate<void()>> KeyDownMap;
-		typedef std::pair<std::string, Fling::Key> KeyDownMapPair;
+		typedef std::pair<std::string, entt::delegate<void()>> KeyDownMapPair;
 
 	protected:
 
@@ -105,3 +110,5 @@ namespace Fling
 	};
 
 }	// namespace Fling
+
+#include "Input.inl"

--- a/FlingEngine/Core/inc/Input/Input.inl
+++ b/FlingEngine/Core/inc/Input/Input.inl
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Input.h"
+
+namespace Fling
+{
+	template<auto Candidate, typename Type>
+	void Input::BindKeyPress(const std::string& t_KeyName, Type& t_Instance)
+	{
+		// Make a new delegate if we have to
+		if(m_KeyDownMap.find(t_KeyName) == m_KeyDownMap.end())
+		{
+            entt::delegate<void()> delegate {};
+			m_KeyDownMap.insert( KeyDownMapPair(t_KeyName, delegate) );
+		}
+
+        // Bind the function
+        m_KeyDownMap[t_KeyName].connect<Candidate>(t_Instance);
+	}
+}   // namespace Fling

--- a/FlingEngine/Core/src/Engine.cpp
+++ b/FlingEngine/Core/src/Engine.cpp
@@ -56,9 +56,11 @@ namespace Fling
 		while(!Renderer.GetCurrentWindow()->ShouldClose())
 		{
 			Renderer.Tick();
+			
+			Input::Poll();
 
 			m_World->Update(DeltaTime);
-		
+			
 			if(m_World->ShouldQuit())
 			{
 				F_LOG_TRACE("World should quit! Exiting engine loop...");

--- a/FlingEngine/Core/src/Input/LinuxInput.cpp
+++ b/FlingEngine/Core/src/Input/LinuxInput.cpp
@@ -13,6 +13,7 @@ namespace Fling
 {
 	Input* Input::m_Instace = new LinuxInput();
 	Input::KeyMap Input::m_KeyMap;
+	Input::KeyDownMap Input::m_KeyDownMap;
 	
 	void LinuxInput::InitImpl()
 	{

--- a/FlingEngine/Core/src/Input/LinuxInput.cpp
+++ b/FlingEngine/Core/src/Input/LinuxInput.cpp
@@ -145,7 +145,13 @@ namespace Fling
 
 	void LinuxInput::PollImpl()
 	{
-		// #TODO: Poll any input keys I guess
+		for(const auto& InputMapping : m_KeyDownMap)
+		{
+			if(IsKeyDown(InputMapping.first) && InputMapping.second)
+			{
+				InputMapping.second();
+			}
+		}
 	}
 	
 	bool LinuxInput::IsKeyDownImpl(const std::string& t_KeyName)

--- a/FlingEngine/Core/src/Input/WindowsInput.cpp
+++ b/FlingEngine/Core/src/Input/WindowsInput.cpp
@@ -15,6 +15,7 @@ namespace Fling
 {
 	Input* Input::m_Instace = new WindowsInput();
 	Input::KeyMap Input::m_KeyMap;
+	Input::KeyDownMap Input::m_KeyDownMap;
 
 	void WindowsInput::InitImpl()
 	{

--- a/FlingEngine/Core/src/Input/WindowsInput.cpp
+++ b/FlingEngine/Core/src/Input/WindowsInput.cpp
@@ -148,7 +148,13 @@ namespace Fling
 
 	void WindowsInput::PollImpl()
 	{
-		// #TODO: Poll any input keys I guess
+		for(const auto& InputMapping : m_KeyDownMap)
+		{
+			if(IsKeyDown(InputMapping.first) && InputMapping.second)
+			{
+				InputMapping.second();
+			}
+		}
 	}
 
 	bool WindowsInput::IsKeyDownImpl(const std::string& t_KeyName)

--- a/FlingEngine/Gameplay/inc/World.h
+++ b/FlingEngine/Gameplay/inc/World.h
@@ -74,6 +74,8 @@ namespace Fling
 		template<class ...ARGS>
 		bool LoadLevelFile(const std::string& t_LevelToLoad);
 
+		FORCEINLINE entt::registry& GetRegistry() const { return m_Registry; }
+
     private:
 		
 		void WriteLevel();

--- a/FlingEngine/Graphics/src/Renderer.cpp
+++ b/FlingEngine/Graphics/src/Renderer.cpp
@@ -44,8 +44,8 @@ namespace Fling
 		CreateFrameBuffers();
 
 		m_TestImage = ResourceManager::LoadResource<Image>("Textures/chalet.jpg"_hs);
-		//m_TestModels.push_back(Model::Create("Models/chalet.obj"_hs));
-		m_TestModels.push_back(Model::Create("Models/cube.obj"_hs));
+		m_TestModels.push_back(Model::Create("Models/chalet.obj"_hs));
+		//m_TestModels.push_back(Model::Create("Models/cube.obj"_hs));
 		//m_TestModels.push_back(Model::Create("Models/cone.obj"_hs));
 
 

--- a/FlingEngine/Utils/inc/pch.h
+++ b/FlingEngine/Utils/inc/pch.h
@@ -23,6 +23,8 @@
 /* Fling Engine Functionality                                           */
 /************************************************************************/
 
+#include <entt/signal/delegate.hpp>
+
 // Enable Fling Logging (even applies in release)
 #define F_ENABLE_LOGGING
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ I am basing the core of the rendering pipeline off of the
 [![Gitter](https://badges.gitter.im/fling-engine/community.svg)](https://gitter.im/fling-engine/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Open Source Helpers](https://www.codetriage.com/flingengine/flingengine/badges/users.svg)](https://www.codetriage.com/flingengine/flingengine)
 [![GitHub license](https://img.shields.io/github/license/flingengine/FlingEngine)](https://github.com/flingengine/FlingEngine/blob/master/LICENSE)
-[![GitHub release](https://img.shields.io/github/release/Naereen/StrapDown.js.svg)](https://github.com/flingengine/FlingEngine/releases)
 [![Work in progress badge](https://img.shields.io/badge/this%20is-a%20work%20in%20progress!-yellow)](https://img.shields.io/badge/this%20is-a%20work%20in%20progress!-yellow)
 
 # Getting Started

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![Fling Engine Logo](docs/Fling-Engine-logo/cover.png)
 
+
+
 The Fling Engine aims to be a cross platform Vulkan game engine that will experiment with the following:
 
 * Low-level engine systems such as render API abstraction, file systems, and custom allocators.
@@ -12,6 +14,9 @@ I am basing the core of the rendering pipeline off of the
 [![Build Status](https://travis-ci.com/flingengine/FlingEngine.svg?branch=master)](https://travis-ci.com/flingengine/FlingEngine)
 [![Gitter](https://badges.gitter.im/fling-engine/community.svg)](https://gitter.im/fling-engine/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Open Source Helpers](https://www.codetriage.com/flingengine/flingengine/badges/users.svg)](https://www.codetriage.com/flingengine/flingengine)
+[![GitHub license](https://img.shields.io/github/license/flingengine/FlingEngine)](https://github.com/flingengine/FlingEngine/blob/master/LICENSE)
+[![GitHub release](https://img.shields.io/github/release/Naereen/StrapDown.js.svg)](https://github.com/flingengine/FlingEngine/releases)
+[![Work in progress badge](https://img.shields.io/badge/this%20is-a%20work%20in%20progress!-yellow)](https://img.shields.io/badge/this%20is-a%20work%20in%20progress!-yellow)
 
 # Getting Started
 

--- a/Sandbox/Gameplay/inc/SandboxGame.h
+++ b/Sandbox/Gameplay/inc/SandboxGame.h
@@ -24,5 +24,17 @@ namespace Sandbox
 		void Update(entt::registry& t_Reg, float DeltaTime) override;
 
 		void OnKeyPress();
+
+		/**
+		 * @brief Called when player presses the button to initate loading
+		 * 
+		 */
+		void OnLoadInitated();
+
+		/**
+		 * @brief Called when the user presses the button to initalize saving
+		 * 
+		 */
+		void OnSaveInitated();
 	};
 }	// namespace Sandbox

--- a/Sandbox/Gameplay/inc/SandboxGame.h
+++ b/Sandbox/Gameplay/inc/SandboxGame.h
@@ -22,5 +22,7 @@ namespace Sandbox
 		* Update is called every frame. Call any system updates for your gameplay systems inside of here
 		*/
 		void Update(entt::registry& t_Reg, float DeltaTime) override;
+
+		void OnKeyPress();
 	};
 }	// namespace Sandbox

--- a/Sandbox/Gameplay/src/SandboxGame.cpp
+++ b/Sandbox/Gameplay/src/SandboxGame.cpp
@@ -13,6 +13,9 @@ namespace Sandbox
 		// Lets create an entity! 
 		F_LOG_TRACE("Sandbox Game Init!");
 		Input::BindKeyPress<&Sandbox::Game::OnKeyPress>(KeyNames::FL_KEY_M, *this);
+
+		Input::BindKeyPress<&Sandbox::Game::OnLoadInitated>(KeyNames::FL_KEY_O, *this);
+		Input::BindKeyPress<&Sandbox::Game::OnSaveInitated>(KeyNames::FL_KEY_P, *this);
 	}
 
 	void Game::Shutdown(entt::registry& t_Reg)
@@ -22,42 +25,49 @@ namespace Sandbox
 
 	void Game::Update(entt::registry& t_Reg, float DeltaTime)
 	{
-		Fling::World* World = GetWorld();
-		assert(World);
 
-		// #TODO Move this input polling to a delete function instead of polling every frame
-		if(Input::IsKeyDown(Fling::KeyNames::FL_KEY_O))
-		{
-			// Add some test entities  -------------------
-			entt::entity e0 = t_Reg.create();
-			t_Reg.assign<Fling::Transform>(e0);
-			t_Reg.assign<Fling::NameComponent>(e0, "Entity 0 Name");
-
-			entt::entity e1 = t_Reg.create();
-			t_Reg.assign<Fling::Transform>(e1);
-			t_Reg.assign<Fling::NameComponent>(e1, "Entity 1 Name");
-			// end For testing -------------------
-
-			// Write out the file
-			World->OutputLevelFile<Fling::NameComponent>(FlingConfig::GetString("Game", "StartLevel"));
-		}
-		else if(Input::IsKeyDown(Fling::KeyNames::FL_KEY_P))
-		{
-			// Load in the file
-			World->LoadLevelFile<Fling::NameComponent>(FlingConfig::GetString("Game", "StartLevel"));
-
-			t_Reg.view<NameComponent, Transform>().each([&](entt::entity t_Ent, NameComponent& t_Name, Transform& t_Trans)
-			{
-				F_LOG_TRACE("Entity has name {}  and pos {},{},{}",
-				 	t_Name.Name, t_Trans.Pos.x, t_Trans.Pos.y, t_Trans.Pos.z
-				);
-			});
-		}
 	}
 
 	void Game::OnKeyPress()
 	{
 		F_LOG_TRACE("THE KEY WAS PRESSED FROM A DELEGATE BOI");
+	}
+
+	void Game::OnLoadInitated()
+	{
+		Fling::World* World = GetWorld();
+		assert(World);
+
+		World->LoadLevelFile<Fling::NameComponent>(FlingConfig::GetString("Game", "StartLevel"));
+		entt::registry& t_Reg = World->GetRegistry();
+		
+		t_Reg.view<NameComponent, Transform>().each([&](entt::entity t_Ent, NameComponent& t_Name, Transform& t_Trans)
+		{
+			F_LOG_TRACE("Entity has name {}  and pos {},{},{}",
+				t_Name.Name, t_Trans.Pos.x, t_Trans.Pos.y, t_Trans.Pos.z
+			);
+		});
+	}
+
+	void Game::OnSaveInitated()
+	{
+		Fling::World* World = GetWorld();
+		assert(World);
+
+		entt::registry& t_Reg = World->GetRegistry();
+
+		// Add some test entities  -------------------
+		entt::entity e0 = t_Reg.create();
+		t_Reg.assign<Fling::Transform>(e0);
+		t_Reg.assign<Fling::NameComponent>(e0, "Entity 0 Name");
+
+		entt::entity e1 = t_Reg.create();
+		t_Reg.assign<Fling::Transform>(e1);
+		t_Reg.assign<Fling::NameComponent>(e1, "Entity 1 Name");
+		// end For testing -------------------
+
+		// Write out the file
+		World->OutputLevelFile<Fling::NameComponent>(FlingConfig::GetString("Game", "StartLevel"));
 	}
 
 }	// namespace Sandbox

--- a/Sandbox/Gameplay/src/SandboxGame.cpp
+++ b/Sandbox/Gameplay/src/SandboxGame.cpp
@@ -12,6 +12,7 @@ namespace Sandbox
 	{
 		// Lets create an entity! 
 		F_LOG_TRACE("Sandbox Game Init!");
+		Input::BindKeyPress<&Sandbox::Game::OnKeyPress>(KeyNames::FL_KEY_M, *this);
 	}
 
 	void Game::Shutdown(entt::registry& t_Reg)
@@ -53,4 +54,10 @@ namespace Sandbox
 			});
 		}
 	}
+
+	void Game::OnKeyPress()
+	{
+		F_LOG_TRACE("THE KEY WAS PRESSED FROM A DELEGATE BOI");
+	}
+
 }	// namespace Sandbox


### PR DESCRIPTION
You can now bind functions to key presses, like this: 

```C
Input::BindKeyPress<&Sandbox::Game::OnLoadInitated>(KeyNames::FL_KEY_O, *this);
```

You simply pass the function as a template arg, give the key you want to listen for, and a reference to the instance. 

See #8 

I also edited the readme to show that this is a work in progress, as well as use the cool house model again in `renderer`