### PR TITLE
Use a ciruclar buffer for our descriptor set binding pools

### DIFF
--- a/FlingEngine/Utils/inc/CircularBuffer.hpp
+++ b/FlingEngine/Utils/inc/CircularBuffer.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "FlingTypes.h"
+
+namespace Fling
+{
+   
+	/**
+	 * @brief	A simple circular buffer that will allow you get the next element in a buffer
+	 *			It does not ensure that the item is not in use, but simply loops around.
+	 */
+    template<typename T, size_t t_Size>
+    class CircularBuffer
+    {
+    public:
+        
+        CircularBuffer();
+
+        ~CircularBuffer() = default;
+
+		T* GetItem();
+
+    private:
+       
+		const UINT32 m_BufferSize;
+		
+		T m_Buffer [t_Size];
+
+		UINT32 m_AllocatedIndex = 0;
+    };
+
+	template<typename T, size_t t_Size>
+	inline CircularBuffer<T, t_Size>::CircularBuffer()
+		: m_BufferSize(t_Size)
+		, m_AllocatedIndex(0)
+		, m_Buffer{}
+	{
+	}
+
+	template<typename T, size_t t_Size>
+	inline T* CircularBuffer<T, t_Size>::GetItem()
+	{
+		const uint32_t index = m_AllocatedIndex++;
+
+		return &(m_Buffer[index & (m_BufferSize - 1u)]);
+	}
+}   // namespace Fling

--- a/FlingEngine/Utils/inc/CircularBuffer.hpp
+++ b/FlingEngine/Utils/inc/CircularBuffer.hpp
@@ -6,8 +6,11 @@ namespace Fling
 {
    
 	/**
-	 * @brief	A simple circular buffer that will allow you get the next element in a buffer
+	 * @brief 	A simple circular buffer that will allow you get the next element in a buffer
 	 *			It does not ensure that the item is not in use, but simply loops around.
+	 * 
+	 * @tparam T 		the type inside this circular buffer. Stack allocated
+	 * @tparam t_Size 	The max size of this buffer, must be a power of 2!
 	 */
     template<typename T, size_t t_Size>
     class CircularBuffer
@@ -35,13 +38,16 @@ namespace Fling
 		, m_AllocatedIndex(0)
 		, m_Buffer{}
 	{
+		static_assert((t_Size != 0 && (t_Size & (t_Size-1)) == 0), "CircularBuffer::t_Size must be a power of 2!");
 	}
 
 	template<typename T, size_t t_Size>
 	inline T* CircularBuffer<T, t_Size>::GetItem()
 	{
 		const uint32_t index = m_AllocatedIndex++;
-
-		return &(m_Buffer[index & (m_BufferSize - 1u)]);
+		// This bit shifting is the same as the % operator
+		// @see https://blog.molecular-matters.com/2015/09/08/job-system-2-0-lock-free-work-stealing-part-2-a-specialized-allocator/
+		// for more about that
+		return &(m_Buffer[(index - 1u) & (m_BufferSize - 1u)]);
 	}
 }   // namespace Fling

--- a/Sandbox/Gameplay/src/SandboxGame.cpp
+++ b/Sandbox/Gameplay/src/SandboxGame.cpp
@@ -83,7 +83,7 @@ namespace Sandbox
 	void Game::GenerateTestMeshes(entt::registry& t_Reg)
 	{
 		// Make a little cube of cubes!
-		int Dimension = 5;
+		int Dimension = 10;
 		float Offset = 2.5f;
 
 		for (int x = 0; x < Dimension; ++x)


### PR DESCRIPTION
## Feature/Issue
Added a simple circular buffer that will reuse objects of type and allow the user to get the next item in a pool. 

Fixes issue #91 

## Implementation/Solution
Some simple bit wise math to loop around the buffer

## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
