### PR TITLE
Implement MSAA

### DIFF
--- a/Config/EngineConf.ini
+++ b/Config/EngineConf.ini
@@ -14,8 +14,8 @@ WindowIconImage=FlingEngineLogo.png
 
 ; Graphics API Settings
 [Vulkan]
-EnableValidationLayers=false
-#EnableValidationLayers=true
+#EnableValidationLayers=false
+EnableValidationLayers=true
 
 [Camera]
 MoveSpeed=10

--- a/Config/EngineConf.ini
+++ b/Config/EngineConf.ini
@@ -14,8 +14,8 @@ WindowIconImage=FlingEngineLogo.png
 
 ; Graphics API Settings
 [Vulkan]
-#EnableValidationLayers=false
-EnableValidationLayers=true
+EnableValidationLayers=false
+#EnableValidationLayers=true
 
 [Camera]
 MoveSpeed=10

--- a/FlingEngine/Graphics/inc/Cubemap.h
+++ b/FlingEngine/Graphics/inc/Cubemap.h
@@ -30,7 +30,7 @@ namespace Fling
 
             ~Cubemap();
 
-            void Init(Camera* t_Camera, UINT32 t_CurrentImage, size_t t_NumeFramesInFlight);
+            void Init(Camera* t_Camera, UINT32 t_CurrentImage, size_t t_NumeFramesInFlight, VkSampleCountFlagBits t_SampleCount);
 
             void UpdateUniformBuffer(UINT32 t_CurrentImage, const glm::mat4& t_ProjectionMatrix, const glm::mat4& t_ViewMatrix);
 
@@ -80,7 +80,7 @@ namespace Fling
 
         private:
 
-            void PreparePipeline();
+            void PreparePipeline(VkSampleCountFlagBits t_SampleCount);
             
             void LoadCubemap(
                 Guid t_PosX_ID,

--- a/FlingEngine/Graphics/inc/DepthBuffer.h
+++ b/FlingEngine/Graphics/inc/DepthBuffer.h
@@ -8,7 +8,7 @@ namespace Fling
 	class DepthBuffer
 	{
 	public:
-		DepthBuffer();
+		explicit DepthBuffer(VkSampleCountFlagBits t_SampleCount);
 
 		~DepthBuffer();
 
@@ -42,6 +42,8 @@ namespace Fling
 		VkImage m_Image = VK_NULL_HANDLE;
 		VkDeviceMemory m_Memory = VK_NULL_HANDLE;
 		VkImageView m_ImageView = VK_NULL_HANDLE;
-		VkFormat m_Format;
+		VkFormat m_Format{};
+
+		VkSampleCountFlagBits m_SampleCount = VK_SAMPLE_COUNT_1_BIT;
 	};
 }   // namespace Fling

--- a/FlingEngine/Graphics/inc/GraphicsHelpers.h
+++ b/FlingEngine/Graphics/inc/GraphicsHelpers.h
@@ -109,11 +109,17 @@ namespace Fling
         /**
          * @brief    Create a an image view for Vulkan with the given format
          */
-        VkImageView CreateVkImageView(VkImage t_Image, VkFormat t_Format, VkImageAspectFlags t_AspectFalgs);
+        VkImageView CreateVkImageView(VkImage t_Image, VkFormat t_Format, VkImageAspectFlags t_AspectFalgs, UINT32 t_MipLevels = 1);
 
         VkFormat FindSupportedFormat(const std::vector<VkFormat>& t_Candidates, VkImageTiling t_Tiling, VkFormatFeatureFlags t_Features);
 
-        void TransitionImageLayout(VkImage t_Image, VkFormat t_Format, VkImageLayout t_oldLayout, VkImageLayout t_NewLayout);
+        void TransitionImageLayout(
+            VkImage t_Image, 
+            VkFormat t_Format, 
+            VkImageLayout t_oldLayout, 
+            VkImageLayout t_NewLayout,
+            UINT32 t_MipLevels = 1
+        );
 
         /**
          * @brief    Returns true if the given format has a stencil component 

--- a/FlingEngine/Graphics/inc/GraphicsHelpers.h
+++ b/FlingEngine/Graphics/inc/GraphicsHelpers.h
@@ -42,7 +42,8 @@ namespace Fling
             VkImageUsageFlags t_Useage,
             VkMemoryPropertyFlags t_Props,
             VkImage& t_Image,
-            VkDeviceMemory& t_Memory
+            VkDeviceMemory& t_Memory,
+			VkSampleCountFlagBits t_NumSamples = VK_SAMPLE_COUNT_1_BIT
         );
 
 		VkSemaphore CreateSemaphore(VkDevice t_Dev);

--- a/FlingEngine/Graphics/inc/GraphicsHelpers.h
+++ b/FlingEngine/Graphics/inc/GraphicsHelpers.h
@@ -59,7 +59,8 @@ namespace Fling
             VkMemoryPropertyFlags t_Props,
             VkImageCreateFlags t_flags,
             VkImage& t_Image,
-            VkDeviceMemory& t_Memory
+            VkDeviceMemory& t_Memory,
+            VkSampleCountFlagBits t_NumSamples = VK_SAMPLE_COUNT_1_BIT
         );
 
         void CreateVkSampler(

--- a/FlingEngine/Graphics/inc/MultiSampler.h
+++ b/FlingEngine/Graphics/inc/MultiSampler.h
@@ -13,11 +13,14 @@ namespace Fling
     {
     public:
 
+		Multisampler(VkSampleCountFlagBits t_SampleCount = VK_SAMPLE_COUNT_1_BIT);
+
         Multisampler(VkExtent2D t_Extents, VkFormat t_Format, VkSampleCountFlagBits t_SampleCount = VK_SAMPLE_COUNT_1_BIT);
 
         ~Multisampler();
 
-        FORCEINLINE const VkSampleCountFlagBits& GetSampleCountFlagBits() const { return m_SampleCountBits; }
+        FORCEINLINE VkSampleCountFlagBits GetSampleCountFlagBits() const { return m_SampleCountBits; }
+		FORCEINLINE const VkImageView& GetImageView() const { return m_ColorImageView; }
 
         void Release();
 

--- a/FlingEngine/Graphics/inc/MultiSampler.h
+++ b/FlingEngine/Graphics/inc/MultiSampler.h
@@ -6,15 +6,23 @@
 namespace Fling
 {
     /**
-     * @brief   A multismapler will allow us to enable MSAA. Should be recreated with the swap chain
+     * @brief   A multi-sampler will allow us to enable MSAA. Should be recreated with the swap chain
      *          as it needs the most up to date extents
      */
     class Multisampler
     {
     public:
 
+		/**
+		* @brief	Creates a multi-sampler with the set sample count, but does not create it
+		*/
 		Multisampler(VkSampleCountFlagBits t_SampleCount = VK_SAMPLE_COUNT_1_BIT);
 
+		/**
+		* @brief	Initializes and creates this multi-sampler.
+		* @param t_Extents		The extents of the current swap chain
+		* @param t_Format		The same image format as your swap chain
+		*/
         Multisampler(VkExtent2D t_Extents, VkFormat t_Format, VkSampleCountFlagBits t_SampleCount = VK_SAMPLE_COUNT_1_BIT);
 
         ~Multisampler();
@@ -22,8 +30,10 @@ namespace Fling
         FORCEINLINE VkSampleCountFlagBits GetSampleCountFlagBits() const { return m_SampleCountBits; }
 		FORCEINLINE const VkImageView& GetImageView() const { return m_ColorImageView; }
 
+		/** Release the Image, Image memory, and Image view of this multi sampler.  */
         void Release();
 
+		/** Create the image, image mem, and image view based on the m_SampleCountBits field. */
         void Create(VkExtent2D t_Extents, VkFormat t_Format);
 
     private:
@@ -31,6 +41,7 @@ namespace Fling
         VkDeviceMemory m_ColorImageMemory = VK_NULL_HANDLE;
         VkImageView m_ColorImageView = VK_NULL_HANDLE;
 
+		/** The max sample count allowed on this device. Calculated in PhysicalDevice ctor */
         VkSampleCountFlagBits m_SampleCountBits = VK_SAMPLE_COUNT_1_BIT;
     }; 
 }   // namespace Fling

--- a/FlingEngine/Graphics/inc/MultiSampler.h
+++ b/FlingEngine/Graphics/inc/MultiSampler.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "FlingVulkan.h"
+#include "Platform.h"       // for FORCEINLINE
+
+namespace Fling
+{
+    /**
+     * @brief   A multismapler will allow us to enable MSAA. Should be recreated with the swap chain
+     *          as it needs the most up to date extents
+     */
+    class Multisampler
+    {
+    public:
+
+        Multisampler(VkExtent2D t_Extents, VkFormat t_Format, VkSampleCountFlagBits t_SampleCount = VK_SAMPLE_COUNT_1_BIT);
+
+        ~Multisampler();
+
+        FORCEINLINE const VkSampleCountFlagBits& GetSampleCountFlagBits() const { return m_SampleCountBits; }
+
+        void Release();
+
+        void Create(VkExtent2D t_Extents, VkFormat t_Format);
+
+    private:
+        VkImage m_ColorImage = VK_NULL_HANDLE;
+        VkDeviceMemory m_ColorImageMemory = VK_NULL_HANDLE;
+        VkImageView m_ColorImageView = VK_NULL_HANDLE;
+
+        VkSampleCountFlagBits m_SampleCountBits = VK_SAMPLE_COUNT_1_BIT;
+    }; 
+}   // namespace Fling

--- a/FlingEngine/Graphics/inc/PhyscialDevice.h
+++ b/FlingEngine/Graphics/inc/PhyscialDevice.h
@@ -36,6 +36,11 @@ namespace Fling
 		/** Logs info about this physical device (vendor, model, ID, etc) to the console/Log file */
 		void LogPhysicalDeviceInfo();
 
+        /**
+         * @brief Checks hte given format properties that are supported on this physical device
+         */
+        VkFormatProperties GetFormatProperties(VkFormat t_Form) const;
+
 		VkSampleCountFlagBits GetMaxUsableSampleCount();
 
     private:

--- a/FlingEngine/Graphics/inc/Renderer.h
+++ b/FlingEngine/Graphics/inc/Renderer.h
@@ -101,6 +101,18 @@ namespace Fling
          */
         static const VkDevice& GetLogicalVkDevice()  { return Renderer::Get().m_LogicalDevice->GetVkDevice(); }
 
+		static VkSampleCountFlagBits GetMsaaSampleCount() 
+		{ 
+			if (Renderer::Get().m_MsaaSampler)
+			{
+				return Renderer::Get().m_MsaaSampler->GetSampleCountFlagBits();
+			}
+			else
+			{
+				return VK_SAMPLE_COUNT_1_BIT;
+			}
+		}
+
         LogicalDevice* GetLogicalDevice() const { return m_LogicalDevice; }
 
         /**

--- a/FlingEngine/Graphics/inc/Renderer.h
+++ b/FlingEngine/Graphics/inc/Renderer.h
@@ -34,6 +34,7 @@
 #include "ImguiDisplay.h"
 #include <atomic>
 #include "Cubemap.h"
+#include "MultiSampler.h"
 
 #include "Lighting/DirectionalLight.hpp"
 #include "Lighting/PointLight.hpp"
@@ -254,6 +255,9 @@ namespace Fling
         VkDescriptorPool m_DescriptorPool;
 
         DepthBuffer* m_DepthBuffer = nullptr;
+
+        /** MSAA for the graphics pipeline */
+        Multisampler* m_MsaaSampler = nullptr;
 
         size_t CurrentFrameIndex = 0;
 

--- a/FlingEngine/Graphics/src/Cubemap.cpp
+++ b/FlingEngine/Graphics/src/Cubemap.cpp
@@ -51,7 +51,7 @@ namespace Fling
         vkDestroySampler(m_Device, m_Sampler, nullptr);   
     }
 
-    void Cubemap::Init(Camera* t_Camera, UINT32 t_CurrentImage, size_t t_NumFramesInFlight)
+    void Cubemap::Init(Camera* t_Camera, UINT32 t_CurrentImage, size_t t_NumFramesInFlight, VkSampleCountFlagBits t_SampleCount)
     {
         // Initialize uniform buffers
         m_numsFrameInFlight = t_NumFramesInFlight;
@@ -69,10 +69,10 @@ namespace Fling
 
         UpdateUniformBuffer(t_CurrentImage, t_Camera->GetProjectionMatrix(), t_Camera->GetViewMatrix());
         SetupDescriptors();
-        PreparePipeline();
+        PreparePipeline(t_SampleCount);
     }
 
-    void Cubemap::PreparePipeline()
+    void Cubemap::PreparePipeline(VkSampleCountFlagBits t_SampleCount)
     {
         VkPipelineInputAssemblyStateCreateInfo inputAssemblyState =
             Initalizers::PipelineInputAssemblyStateCreateInfo(
@@ -109,7 +109,7 @@ namespace Fling
 
         VkPipelineMultisampleStateCreateInfo multisampleState =
             Initalizers::PipelineMultiSampleStateCreateInfo(
-                VK_SAMPLE_COUNT_1_BIT,
+                t_SampleCount,
                 0);
 
 

--- a/FlingEngine/Graphics/src/DepthBuffer.cpp
+++ b/FlingEngine/Graphics/src/DepthBuffer.cpp
@@ -5,7 +5,7 @@
 
 namespace Fling
 {
-	DepthBuffer::DepthBuffer(VkSampleCountFlagBits t_SampleCount = VK_SAMPLE_COUNT_1_BIT)
+	DepthBuffer::DepthBuffer(VkSampleCountFlagBits t_SampleCount)
 		: m_SampleCount(t_SampleCount)
 	{
 		Create();

--- a/FlingEngine/Graphics/src/DepthBuffer.cpp
+++ b/FlingEngine/Graphics/src/DepthBuffer.cpp
@@ -5,7 +5,8 @@
 
 namespace Fling
 {
-	DepthBuffer::DepthBuffer()
+	DepthBuffer::DepthBuffer(VkSampleCountFlagBits t_SampleCount = VK_SAMPLE_COUNT_1_BIT)
+		: m_SampleCount(t_SampleCount)
 	{
 		Create();
 	}
@@ -78,7 +79,8 @@ namespace Fling
 			/* Usage */ VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
 			/* Props */ VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 			m_Image,
-			m_Memory
+			m_Memory,
+			m_SampleCount
 		);
 	}
 

--- a/FlingEngine/Graphics/src/GraphicsHelpers.cpp
+++ b/FlingEngine/Graphics/src/GraphicsHelpers.cpp
@@ -127,7 +127,9 @@ namespace Fling
             VkMemoryPropertyFlags t_Props, 
             VkImageCreateFlags t_flags,
             VkImage& t_Image, 
-            VkDeviceMemory& t_Memory)
+            VkDeviceMemory& t_Memory, 
+            VkSampleCountFlagBits t_NumSamples
+            )
         {
             VkDevice Device = Renderer::Get().GetLogicalVkDevice();
             VkPhysicalDevice PhysDevice = Renderer::Get().GetPhysicalVkDevice();
@@ -147,7 +149,7 @@ namespace Fling
             imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
             imageInfo.usage = t_Useage;
 
-            imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+            imageInfo.samples = t_NumSamples;
             imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
             imageInfo.flags = t_flags;
 

--- a/FlingEngine/Graphics/src/GraphicsHelpers.cpp
+++ b/FlingEngine/Graphics/src/GraphicsHelpers.cpp
@@ -109,10 +109,25 @@ namespace Fling
             VkImageUsageFlags t_Useage, 
             VkMemoryPropertyFlags t_Props, 
             VkImage& t_Image,
-            VkDeviceMemory& t_Memory
+            VkDeviceMemory& t_Memory,
+			VkSampleCountFlagBits t_NumSamples
         )
         {
-            CreateVkImage(t_Width, t_Height, 1, 1, 1, t_Format, t_Tiling, t_Useage, t_Props, 0, t_Image, t_Memory);
+            CreateVkImage(
+				t_Width, 
+				t_Height, 
+				/* t_MipLevels */ 1, 
+				/* t_Depth */ 1, 
+				/* t_ArrayLayers */ 1, 
+				t_Format, 
+				t_Tiling, 
+				t_Useage, 
+				t_Props, 
+				/* t_flags */ 0, 
+				t_Image, 
+				t_Memory,
+				t_NumSamples
+			);
         }
 
         void CreateVkImage(
@@ -460,9 +475,16 @@ namespace Fling
                 SourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
                 DestinationStage = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
             }
-            else 
+			else if (t_oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && t_NewLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+			{
+				barrier.srcAccessMask = 0;
+				barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+				SourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+				DestinationStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+			}
+            else
             {
-                F_LOG_ERROR("Unsupported layout transition!");
+                F_LOG_FATAL("Unsupported layout transition!");
             }
 
             vkCmdPipelineBarrier(

--- a/FlingEngine/Graphics/src/GraphicsHelpers.cpp
+++ b/FlingEngine/Graphics/src/GraphicsHelpers.cpp
@@ -392,7 +392,13 @@ namespace Fling
 
         }
 
-        void TransitionImageLayout(VkImage t_Image, VkFormat t_Format, VkImageLayout t_oldLayout, VkImageLayout t_NewLayout)
+        void TransitionImageLayout(
+            VkImage t_Image, 
+            VkFormat t_Format, 
+            VkImageLayout t_oldLayout, 
+            VkImageLayout t_NewLayout,
+            UINT32 t_MipLevels /* = 1 */
+        )
         {
             VkCommandBuffer commandBuffer = GraphicsHelpers::BeginSingleTimeCommands();
 
@@ -420,7 +426,7 @@ namespace Fling
             }
 
             barrier.subresourceRange.baseMipLevel = 0;
-            barrier.subresourceRange.levelCount = 1;
+            barrier.subresourceRange.levelCount = t_MipLevels;        // TODO: Set this as the mip levels passed in
             barrier.subresourceRange.baseArrayLayer = 0;
             barrier.subresourceRange.layerCount = 1;
 
@@ -469,7 +475,12 @@ namespace Fling
             GraphicsHelpers::EndSingleTimeCommands(commandBuffer);
         }
 
-        VkImageView CreateVkImageView(VkImage t_Image, VkFormat t_Format, VkImageAspectFlags t_AspectFalgs)
+        VkImageView CreateVkImageView(
+            VkImage t_Image, 
+            VkFormat t_Format, 
+            VkImageAspectFlags t_AspectFalgs, 
+            UINT32 t_MipLevels
+        )
         {
             VkDevice Device = Renderer::Get().GetLogicalVkDevice();
 
@@ -487,6 +498,7 @@ namespace Fling
             createInfo.subresourceRange.levelCount = 1;
             createInfo.subresourceRange.baseArrayLayer = 0;
             createInfo.subresourceRange.layerCount = 1;
+            createInfo.subresourceRange.levelCount = t_MipLevels;
 
             VkImageView imageView = VK_NULL_HANDLE;
             if (vkCreateImageView(Device, &createInfo, nullptr, &imageView) != VK_SUCCESS)

--- a/FlingEngine/Graphics/src/MultiSampler.cpp
+++ b/FlingEngine/Graphics/src/MultiSampler.cpp
@@ -1,0 +1,74 @@
+#include "pch.h"
+#include "MultiSampler.h"
+#include "Renderer.h"
+#include "GraphicsHelpers.h"
+
+namespace Fling
+{
+    Multisampler::Multisampler(VkExtent2D t_Extents, VkFormat t_Format, VkSampleCountFlagBits t_SampleCount /* = VK_SAMPLE_COUNT_1_BIT */)
+        : m_SampleCountBits(t_SampleCount)
+    {
+        Create(t_Extents, t_Format);
+    }
+
+    void Multisampler::Create(VkExtent2D t_Extents, VkFormat t_Format)
+    {
+        VkFormat colorFormat = t_Format;
+
+        //GraphicsHelpers::CreateVkImage(
+        //    t_Extents.width,
+        //    t_Extents.height, 
+        //    /** Mip levels */ 1, 
+        //    m_SampleCountBits, 
+        //    colorFormat, 
+        //    VK_IMAGE_TILING_OPTIMAL, 
+        //    VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 
+        //    VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 
+        //    m_ColorImage, 
+        //    m_ColorImageMemory
+        //);
+        
+        m_ColorImageView = GraphicsHelpers::CreateVkImageView(
+            m_ColorImage, 
+            colorFormat, 
+            VK_IMAGE_ASPECT_COLOR_BIT, 
+            1
+        );
+
+        GraphicsHelpers::TransitionImageLayout(
+            m_ColorImage, 
+            colorFormat, 
+            VK_IMAGE_LAYOUT_UNDEFINED, 
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, 
+            /* mip levels */ 1
+        );
+    }
+
+    void Multisampler::Release()
+    {
+        VkDevice device = Renderer::Get().GetLogicalVkDevice();
+        if(m_ColorImage != VK_NULL_HANDLE)
+        {
+            vkDestroyImage(device, m_ColorImage, nullptr);
+            m_ColorImage = VK_NULL_HANDLE;
+        }
+
+        if(m_ColorImageView != VK_NULL_HANDLE)
+        {
+            vkDestroyImageView(device, m_ColorImageView, nullptr);
+            m_ColorImageView = VK_NULL_HANDLE;
+        }
+
+        if(m_ColorImageMemory != VK_NULL_HANDLE)
+        {
+            vkFreeMemory(device, m_ColorImageMemory, nullptr);
+            m_ColorImageMemory = VK_NULL_HANDLE;
+        }
+    }
+
+    Multisampler::~Multisampler()
+    {
+        Release();
+    }
+
+}   // namespace Fling

--- a/FlingEngine/Graphics/src/MultiSampler.cpp
+++ b/FlingEngine/Graphics/src/MultiSampler.cpp
@@ -5,7 +5,12 @@
 
 namespace Fling
 {
-    Multisampler::Multisampler(VkExtent2D t_Extents, VkFormat t_Format, VkSampleCountFlagBits t_SampleCount /* = VK_SAMPLE_COUNT_1_BIT */)
+	Multisampler::Multisampler(VkSampleCountFlagBits t_SampleCount)
+		: m_SampleCountBits(t_SampleCount)
+	{
+	}
+
+	Multisampler::Multisampler(VkExtent2D t_Extents, VkFormat t_Format, VkSampleCountFlagBits t_SampleCount /* = VK_SAMPLE_COUNT_1_BIT */)
         : m_SampleCountBits(t_SampleCount)
     {
         Create(t_Extents, t_Format);
@@ -15,33 +20,36 @@ namespace Fling
     {
         VkFormat colorFormat = t_Format;
 
-        //GraphicsHelpers::CreateVkImage(
-        //    t_Extents.width,
-        //    t_Extents.height, 
-        //    /** Mip levels */ 1, 
-        //    m_SampleCountBits, 
-        //    colorFormat, 
-        //    VK_IMAGE_TILING_OPTIMAL, 
-        //    VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 
-        //    VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 
-        //    m_ColorImage, 
-        //    m_ColorImageMemory
-        //);
-        
-        m_ColorImageView = GraphicsHelpers::CreateVkImageView(
-            m_ColorImage, 
-            colorFormat, 
-            VK_IMAGE_ASPECT_COLOR_BIT, 
-            1
-        );
+		GraphicsHelpers::CreateVkImage(
+			t_Extents.width,
+			t_Extents.height,
+			/** Mip levels */ 1,
+			/* Depth */ 1,
+			/* Array Layers */ 1,
+			/* Format */ colorFormat,
+			/* Tiling */ VK_IMAGE_TILING_OPTIMAL,
+			/* Usage */ VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+			/* Props */ VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+			/* Flags */ 0,
+			m_ColorImage,
+			m_ColorImageMemory,
+			m_SampleCountBits
+		);
 
-        GraphicsHelpers::TransitionImageLayout(
-            m_ColorImage, 
-            colorFormat, 
-            VK_IMAGE_LAYOUT_UNDEFINED, 
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, 
-            /* mip levels */ 1
-        );
+		m_ColorImageView = GraphicsHelpers::CreateVkImageView(
+			m_ColorImage,
+			colorFormat,
+			VK_IMAGE_ASPECT_COLOR_BIT,
+			1
+		);
+
+		GraphicsHelpers::TransitionImageLayout(
+			m_ColorImage,
+			colorFormat,
+			VK_IMAGE_LAYOUT_UNDEFINED,
+			VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+			/* mip levels */ 1
+		);
     }
 
     void Multisampler::Release()

--- a/FlingEngine/Graphics/src/MultiSampler.cpp
+++ b/FlingEngine/Graphics/src/MultiSampler.cpp
@@ -18,15 +18,15 @@ namespace Fling
 
     void Multisampler::Create(VkExtent2D t_Extents, VkFormat t_Format)
     {
-        VkFormat colorFormat = t_Format;
+		// t_Format should the same format as the swap chain
 
 		GraphicsHelpers::CreateVkImage(
 			t_Extents.width,
 			t_Extents.height,
-			/** Mip levels */ 1,
+			/* Mip levels */ 1,
 			/* Depth */ 1,
 			/* Array Layers */ 1,
-			/* Format */ colorFormat,
+			/* Format */ t_Format,
 			/* Tiling */ VK_IMAGE_TILING_OPTIMAL,
 			/* Usage */ VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
 			/* Props */ VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
@@ -38,14 +38,14 @@ namespace Fling
 
 		m_ColorImageView = GraphicsHelpers::CreateVkImageView(
 			m_ColorImage,
-			colorFormat,
+			t_Format,
 			VK_IMAGE_ASPECT_COLOR_BIT,
 			1
 		);
 
 		GraphicsHelpers::TransitionImageLayout(
 			m_ColorImage,
-			colorFormat,
+			t_Format,
 			VK_IMAGE_LAYOUT_UNDEFINED,
 			VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
 			/* mip levels */ 1

--- a/FlingEngine/Graphics/src/PhyscialDevice.cpp
+++ b/FlingEngine/Graphics/src/PhyscialDevice.cpp
@@ -39,6 +39,14 @@ namespace Fling
 		LogPhysicalDeviceInfo();
     }
 
+	VkFormatProperties PhysicalDevice::GetFormatProperties(VkFormat t_Form) const
+	{
+		assert(m_PhysicalDevice != VK_NULL_HANDLE);
+		VkFormatProperties formatProperties = {};
+    	vkGetPhysicalDeviceFormatProperties(m_PhysicalDevice, t_Form, &formatProperties);
+		return formatProperties;
+	}
+
 	const char* PhysicalDevice::GetDeviceType(VkPhysicalDeviceProperties t_Props)
 	{
 		switch (static_cast<UINT32>(t_Props.deviceType))

--- a/FlingEngine/Graphics/src/Renderer.cpp
+++ b/FlingEngine/Graphics/src/Renderer.cpp
@@ -46,6 +46,7 @@ namespace Fling
 
 	void Renderer::InitGraphics()
 	{
+		m_MsaaSampler = new Multisampler(m_PhysicalDevice->GetMaxUsableSampleCount());
 		CreateRenderPass();
 
         GraphicsHelpers::CreateCommandPool(&m_CommandPool, 0);
@@ -56,7 +57,9 @@ namespace Fling
 
 		CreateGraphicsPipeline();
 
-        m_DepthBuffer = new DepthBuffer();
+		m_MsaaSampler->Create(m_SwapChain->GetExtents(), m_SwapChain->GetImageFormat());
+
+        m_DepthBuffer = new DepthBuffer(m_PhysicalDevice->GetMaxUsableSampleCount());
         assert(m_DepthBuffer);
 
         // Create the camera
@@ -81,20 +84,20 @@ namespace Fling
             m_CommandPool);
 
         // Load Skybox
-        m_Skybox = new Cubemap(
-            "Textures/Skybox/posx.jpg"_hs,
-            "Textures/Skybox/negx.jpg"_hs,
-            "Textures/Skybox/posy.jpg"_hs,
-            "Textures/Skybox/negy.jpg"_hs,
-            "Textures/Skybox/posz.jpg"_hs,
-            "Textures/Skybox/negz.jpg"_hs,
-            HS("Shaders/skybox/skybox.vert.spv"),
-            HS("Shaders/skybox/skybox.frag.spv"),
-            m_RenderPass,
-            m_LogicalDevice->GetVkDevice()
-        );
+		m_Skybox = new Cubemap(
+			"Textures/Skybox/posx.jpg"_hs,
+			"Textures/Skybox/negx.jpg"_hs,
+			"Textures/Skybox/posy.jpg"_hs,
+			"Textures/Skybox/negy.jpg"_hs,
+			"Textures/Skybox/posz.jpg"_hs,
+			"Textures/Skybox/negz.jpg"_hs,
+			HS("Shaders/skybox/skybox.vert.spv"),
+			HS("Shaders/skybox/skybox.frag.spv"),
+			m_RenderPass,
+			m_LogicalDevice->GetVkDevice()
+		);
 
-        m_Skybox->Init(m_camera, m_SwapChain->GetActiveImageIndex(), m_SwapChain->GetImageViewCount());
+		m_Skybox->Init(m_camera, m_SwapChain->GetActiveImageIndex(), m_SwapChain->GetImageViewCount(), m_PhysicalDevice->GetMaxUsableSampleCount());
 
         CreateLightBuffers();
 
@@ -125,10 +128,6 @@ namespace Fling
         const std::vector<VkImage>& Images = m_SwapChain->GetImages();
 		VkDeviceSize bufferSize = sizeof(m_LightingUBO);
 
-        F_LOG_TRACE("Sizeof DirLight   : {} , alignof {}", sizeof(DirectionalLight), alignof(DirectionalLight));
-        F_LOG_TRACE("Sizeof PointLight : {} , alignof {}", sizeof(PointLight), alignof(PointLight));
-        F_LOG_TRACE("Light UBO         : {} , alignof {}", sizeof(LightingUbo), alignof(LightingUbo));
-
 		m_Lighting.m_LightingUBOs.resize(Images.size());
 		for (size_t i = 0; i < Images.size(); i++)
 		{
@@ -155,10 +154,12 @@ namespace Fling
 
     void Renderer::CreateRenderPass()
     {
+		assert(m_MsaaSampler && m_SwapChain);
+
         // We have a single color buffer for the images in the swap chain
         VkAttachmentDescription ColorAttachment = {};
         ColorAttachment.format = m_SwapChain->GetImageFormat();
-        ColorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
+        ColorAttachment.samples = m_MsaaSampler->GetSampleCountFlagBits();
         ColorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;       // Clear the frame buffer to black
         ColorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 
@@ -166,18 +167,29 @@ namespace Fling
         ColorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 
         ColorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        //Change to VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL  for imgui
+        // Change to VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL  for imgui
+		// and because multisampled images cannot be presented directly
         ColorAttachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
         VkAttachmentDescription DepthAttatchment = {};
         DepthAttatchment.format = DepthBuffer::GetDepthBufferFormat();
-        DepthAttatchment.samples = VK_SAMPLE_COUNT_1_BIT;
+        DepthAttatchment.samples = m_MsaaSampler->GetSampleCountFlagBits();
         DepthAttatchment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
         DepthAttatchment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
         DepthAttatchment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         DepthAttatchment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
         DepthAttatchment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
         DepthAttatchment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+		VkAttachmentDescription colorAttachmentResolve = {};
+		colorAttachmentResolve.format = m_SwapChain->GetImageFormat();
+		colorAttachmentResolve.samples = VK_SAMPLE_COUNT_1_BIT;
+		colorAttachmentResolve.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+		colorAttachmentResolve.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+		colorAttachmentResolve.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+		colorAttachmentResolve.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+		colorAttachmentResolve.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+		colorAttachmentResolve.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
         // Subpass -------------------
         VkAttachmentReference ColorAttachmentRef = {};
@@ -188,12 +200,17 @@ namespace Fling
         DepthAttatchmentRef.attachment = 1;
         DepthAttatchmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
+		VkAttachmentReference colorAttachmentResolveRef = {};
+		colorAttachmentResolveRef.attachment = 2;
+		colorAttachmentResolveRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
         VkSubpassDescription Subpass = {};
         Subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;    // You need to be explicit that this is
                                                                         // a graphics subpass because we may support compute passes in the future
         Subpass.colorAttachmentCount = 1;
         Subpass.pColorAttachments = &ColorAttachmentRef;
         Subpass.pDepthStencilAttachment = &DepthAttatchmentRef;
+		Subpass.pResolveAttachments = &colorAttachmentResolveRef;
 
         // Add a subpass dependency
         VkSubpassDependency dependency = {};
@@ -205,7 +222,7 @@ namespace Fling
         dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 
         // Create the render pass
-        std::array<VkAttachmentDescription, 2> Attachments = { ColorAttachment, DepthAttatchment };
+        std::array<VkAttachmentDescription, 3> Attachments = { ColorAttachment, DepthAttatchment, colorAttachmentResolve };
         VkRenderPassCreateInfo renderPassInfo = {};
         renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
         renderPassInfo.attachmentCount = static_cast<UINT32>(Attachments.size());
@@ -304,11 +321,12 @@ namespace Fling
         // Multi-sampling ----------------------------------
         // Can be a cheaper way to perform anti-aliasing
         // Using it requires enabling a GPU feature
+		assert(m_MsaaSampler);
         VkPipelineMultisampleStateCreateInfo Multisampling = {};
         {
             Multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
             Multisampling.sampleShadingEnable = VK_TRUE;
-            Multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+            Multisampling.rasterizationSamples = m_MsaaSampler->GetSampleCountFlagBits();
             Multisampling.minSampleShading = 0.2f; 
             Multisampling.pSampleMask = nullptr; // Optional
             Multisampling.alphaToCoverageEnable = VK_FALSE; // Optional
@@ -397,7 +415,7 @@ namespace Fling
 
     void Renderer::CreateFrameBuffers()
     {
-        assert(m_SwapChain && m_DepthBuffer);
+        assert(m_SwapChain && m_DepthBuffer && m_MsaaSampler);
 
         m_SwapChainFramebuffers.resize(m_SwapChain->GetImageViewCount());
 
@@ -406,10 +424,11 @@ namespace Fling
         // Create the frame buffers based on the image views
         for (size_t i = 0; i < m_SwapChain->GetImageViewCount(); i++)
         {
-            std::array<VkImageView, 2> attachments =
+            std::array<VkImageView, 3> attachments =
             {
-                ImageViews[i],
-                m_DepthBuffer->GetVkImageView()
+				m_MsaaSampler->GetImageView(),
+                m_DepthBuffer->GetVkImageView(),
+				ImageViews[i]
             };
 
             VkFramebufferCreateInfo framebufferInfo = {};
@@ -467,17 +486,17 @@ namespace Fling
             vkCmdSetScissor(m_CommandBuffers[i], 0, 1, &scissor);
 
             // Skybox -----------------------------
-            VkBuffer skyboxVertexBuffers[1] = { m_Skybox->GetVertexBuffer()->GetVkBuffer() };
-            VkDeviceSize offsets[1] = { 0 };
-            VkDescriptorSet skyboxDescriptorSet[1] = { m_Skybox->GetDescriptorSet() };
+			VkBuffer skyboxVertexBuffers[1] = { m_Skybox->GetVertexBuffer()->GetVkBuffer() };
+			VkDeviceSize offsets[1] = { 0 };
+			VkDescriptorSet skyboxDescriptorSet[1] = { m_Skybox->GetDescriptorSet() };
 
-            vkCmdBindDescriptorSets(m_CommandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, m_Skybox->GetPipelineLayout(), 0, 1, skyboxDescriptorSet, 0, NULL);
-            vkCmdBindVertexBuffers(m_CommandBuffers[i], 0, 1, skyboxVertexBuffers, offsets);
-            vkCmdBindIndexBuffer(m_CommandBuffers[i], m_Skybox->GetIndexBuffer()->GetVkBuffer(), 0, m_Skybox->GetIndexType());
-            vkCmdBindPipeline(m_CommandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, m_Skybox->GetPipeLine());
-            vkCmdDrawIndexed(m_CommandBuffers[i], m_Skybox->GetIndexCount(), 1, 0, 0, 0);
-
-            vkCmdBindPipeline(m_CommandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, m_GraphicsPipeline);
+			vkCmdBindDescriptorSets(m_CommandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, m_Skybox->GetPipelineLayout(), 0, 1, skyboxDescriptorSet, 0, NULL);
+			vkCmdBindVertexBuffers(m_CommandBuffers[i], 0, 1, skyboxVertexBuffers, offsets);
+			vkCmdBindIndexBuffer(m_CommandBuffers[i], m_Skybox->GetIndexBuffer()->GetVkBuffer(), 0, m_Skybox->GetIndexType());
+			vkCmdBindPipeline(m_CommandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, m_Skybox->GetPipeLine());
+			vkCmdDrawIndexed(m_CommandBuffers[i], m_Skybox->GetIndexCount(), 1, 0, 0, 0);
+			
+			vkCmdBindPipeline(m_CommandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, m_GraphicsPipeline);
 
 
             // For each active mesh renderer, bind it's vertex and index buffer
@@ -994,6 +1013,18 @@ namespace Fling
             m_SwapChain = nullptr;
         }
 		
+		if (m_DepthBuffer)
+		{
+			delete m_DepthBuffer;
+			m_DepthBuffer = nullptr;
+		}
+
+		if (m_MsaaSampler)
+		{
+			delete m_MsaaSampler;
+			m_MsaaSampler = nullptr;
+		}
+
         vkDestroyDescriptorSetLayout(m_LogicalDevice->GetVkDevice(), m_DescriptorSetLayout, nullptr);
 
         for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++)
@@ -1002,8 +1033,6 @@ namespace Fling
             vkDestroySemaphore(m_LogicalDevice->GetVkDevice(), m_ImageAvailableSemaphores[i], nullptr);
             vkDestroyFence(m_LogicalDevice->GetVkDevice(), m_InFlightFences[i], nullptr);
         }
-
-
 
         vkDestroyCommandPool(m_LogicalDevice->GetVkDevice(), m_CommandPool, nullptr);
 

--- a/FlingEngine/Graphics/src/Renderer.cpp
+++ b/FlingEngine/Graphics/src/Renderer.cpp
@@ -536,6 +536,10 @@ namespace Fling
     void Renderer::CleanupFrameResources()
     {
         m_DepthBuffer->Cleanup();
+		if (m_MsaaSampler)
+		{
+			m_MsaaSampler->Release();
+		}
 
         for (size_t i = 0; i < m_SwapChainFramebuffers.size(); i++)
         {
@@ -567,6 +571,10 @@ namespace Fling
         CreateGraphicsPipeline();
 
         m_DepthBuffer->Create();
+		if (m_MsaaSampler)
+		{
+			m_MsaaSampler->Create(m_SwapChain->GetExtents(), m_SwapChain->GetImageFormat());
+		}
 
         CreateFrameBuffers();
 

--- a/FlingEngine/Resources/inc/Image.h
+++ b/FlingEngine/Resources/inc/Image.h
@@ -20,7 +20,8 @@ namespace Fling
 		FORCEINLINE UINT32 GetWidth() const { return m_Width; }
 		FORCEINLINE UINT32 GetHeight() const { return m_Height; }
 		FORCEINLINE INT32 GetChannels() const { return m_Channels; }
-        
+        FORCEINLINE UINT32 GetMipLevels() const { return m_MipLevels; }
+
 		FORCEINLINE const VkImage& GetVkImage() const { return m_vVkImage; }
 		FORCEINLINE const VkImageView& GetVkImageView() const { return m_ImageView; }
 		FORCEINLINE const VkSampler& GetSampler() const { return m_TextureSampler; }
@@ -61,11 +62,15 @@ namespace Fling
 
 		void CopyBufferToImage(VkBuffer t_Buffer);
 
+        void GenerateMipMaps(VkFormat imageFormat);
+
         /** Width of this image */
 		UINT32 m_Width = 0;
 
         /** Height of this image */
 		UINT32 m_Height = 0;
+
+        UINT32 m_MipLevels = 0;
 
         /** The color channels of this image */
         INT32 m_Channels = 0;

--- a/FlingEngine/Resources/src/Image.cpp
+++ b/FlingEngine/Resources/src/Image.cpp
@@ -230,7 +230,8 @@ namespace Fling
         m_ImageView = GraphicsHelpers::CreateVkImageView(
             m_vVkImage,
             VK_FORMAT_R8G8B8A8_UNORM, 
-            VK_IMAGE_ASPECT_COLOR_BIT
+            VK_IMAGE_ASPECT_COLOR_BIT,
+            m_MipLevels
         );
         assert(m_ImageView != VK_NULL_HANDLE);
     }

--- a/FlingEngine/Resources/src/Image.cpp
+++ b/FlingEngine/Resources/src/Image.cpp
@@ -50,6 +50,7 @@ namespace Fling
 
         m_Width = static_cast<UINT32>(Width);
         m_Height = static_cast<UINT32>(Height);
+        m_MipLevels = static_cast<UINT32>(std::floor(std::log2(std::max(m_Width, m_Height)))) + 1;
 
         if (!m_PixelData)
         {
@@ -63,10 +64,14 @@ namespace Fling
         GraphicsHelpers::CreateVkImage(
             m_Width,
             m_Height,
+            m_MipLevels, 
+            /* Depth */ 1,
+            /* Array Layers */ 1,
             /* Format */ VK_FORMAT_R8G8B8A8_UNORM,
             /* Tiling */ VK_IMAGE_TILING_OPTIMAL,
-            /* Usage */ VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+            /* Usage */ VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
             /* Props */ VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+            /* Flags */ 0, 
             m_vVkImage,
             m_VkMemory
         );
@@ -76,11 +81,115 @@ namespace Fling
         Buffer StagingBuffer(ImageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, m_PixelData);
         
         // Transition and copy the image layout to the staging buffer
-        GraphicsHelpers::TransitionImageLayout(m_vVkImage, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+        GraphicsHelpers::TransitionImageLayout(
+            m_vVkImage, 
+            VK_FORMAT_R8G8B8A8_UNORM, 
+            VK_IMAGE_LAYOUT_UNDEFINED, 
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            m_MipLevels
+        );
         CopyBufferToImage(StagingBuffer.GetVkBuffer());
 
-        // transition the image memory to be optimal so that we can sample it in the shader
-        GraphicsHelpers::TransitionImageLayout(m_vVkImage, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        // Transition to image layout happens while generating mip maps
+        GenerateMipMaps(VK_FORMAT_R8G8B8A8_UNORM);
+    }
+
+    void Image::GenerateMipMaps(VkFormat imageFormat)
+    {
+        // Check that we have linear filtering support on this device
+        VkFormatProperties formatProperties = Renderer::Get().GetPhysicalDevice()->GetFormatProperties(imageFormat);
+
+        if (!(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) 
+        {
+            F_LOG_FATAL("Texture image format does not support linear blitting!");
+        }
+
+        VkCommandBuffer commandBuffer = GraphicsHelpers::BeginSingleTimeCommands();
+
+        VkImageMemoryBarrier barrier = {};
+        barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barrier.image = m_vVkImage;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        barrier.subresourceRange.baseArrayLayer = 0;
+        barrier.subresourceRange.layerCount = 1;
+        barrier.subresourceRange.levelCount = 1;
+
+        INT32 mipWidth = m_Width;
+        INT32 mipHeight = m_Height;
+
+        for(UINT32 i = 1; i < m_MipLevels; i++)
+        {
+            barrier.subresourceRange.baseMipLevel = i - 1;
+            barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+
+            vkCmdPipelineBarrier(commandBuffer,
+                VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                0, nullptr,
+                0, nullptr,
+                1, &barrier
+            );
+
+            VkImageBlit blit = {};
+            blit.srcOffsets[0] = { 0, 0, 0 };
+            blit.srcOffsets[1] = { mipWidth, mipHeight, 1 };
+            blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            blit.srcSubresource.mipLevel = i - 1;
+            blit.srcSubresource.baseArrayLayer = 0;
+            blit.srcSubresource.layerCount = 1;
+            blit.dstOffsets[0] = { 0, 0, 0 };
+            blit.dstOffsets[1] = { mipWidth > 1 ? mipWidth / 2 : 1, mipHeight > 1 ? mipHeight / 2 : 1, 1 };
+            blit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            blit.dstSubresource.mipLevel = i;
+            blit.dstSubresource.baseArrayLayer = 0;
+            blit.dstSubresource.layerCount = 1;
+
+            vkCmdBlitImage(commandBuffer,
+                m_vVkImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                m_vVkImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                1, &blit,
+                VK_FILTER_LINEAR
+            );
+
+            barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+            vkCmdPipelineBarrier(commandBuffer,
+                VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
+                0, nullptr,
+                0, nullptr,
+                1, &barrier
+            );
+
+            if (mipWidth > 1) 
+            {
+                mipWidth /= 2;
+            }
+            if (mipHeight > 1)
+            {
+                mipHeight /= 2;
+            } 
+        }
+
+        barrier.subresourceRange.baseMipLevel = m_MipLevels - 1;
+        barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+        vkCmdPipelineBarrier(commandBuffer,
+            VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
+            0, nullptr,
+            0, nullptr,
+            1, &barrier);
+
+        GraphicsHelpers::EndSingleTimeCommands(commandBuffer);
     }
 
     void Image::CopyBufferToImage(VkBuffer t_Buffer)
@@ -148,7 +257,7 @@ namespace Fling
         SamplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
         SamplerInfo.mipLodBias = 0.0f;
         SamplerInfo.minLod = 0.0f;
-        SamplerInfo.maxLod = 0.0f;
+        SamplerInfo.maxLod = static_cast<float>(m_MipLevels);
 
         VkDevice Device = Renderer::Get().GetLogicalVkDevice();
 

--- a/Sandbox/Gameplay/inc/Mover.h
+++ b/Sandbox/Gameplay/inc/Mover.h
@@ -3,7 +3,7 @@
 /** A mover will move between two values ata  given speed */
 struct Mover
 {
-    float MinPos = -4.0f;
-    float MaxPos = 4.0f;
+    float MinPos = -10.0f;
+    float MaxPos = 10.0f;
     float Speed = 1.0f;
 };

--- a/Sandbox/Gameplay/src/SandboxGame.cpp
+++ b/Sandbox/Gameplay/src/SandboxGame.cpp
@@ -108,12 +108,13 @@ namespace Sandbox
 
 	void Game::LightingTest(entt::registry& t_Reg)
 	{
-		auto AddSphere = [&](UINT32 t_Itr,  const std::string& t_Model, const std::string& t_Mat) 
+		auto AddModel = [&](UINT32 t_Itr,  const std::string& t_Model, const std::string& t_Mat, const glm::vec3 t_Scale = glm::vec3(1.0f)) 
 		{
 			entt::entity e0 = t_Reg.create();
 			t_Reg.assign<MeshRenderer>(e0, t_Model, t_Mat);
 			Transform& t0 = t_Reg.assign<Transform>(e0);
 			t0.SetPos(glm::vec3(-2.0f + (1.5f * (float)t_Itr), 0.0f, 0.0f));
+			t0.SetScale(t_Scale);
 		};
 
 		auto AddRandomPointLight = [&]()
@@ -137,24 +138,25 @@ namespace Sandbox
 			Mover& m0 = t_Reg.assign<Mover>(e0);
 
 			Light.DiffuseColor = glm::vec4(t_Color, 1.0f);
-			Light.Intensity = 5.0f;
-			Light.Range = 3.0f;
+			Light.Intensity = 10.0f;
+			Light.Range = 10.0f;
 
 			t0.SetPos(t_Pos);
 		};
 
-		AddSphere(0, "Models/Cerberus.obj", "Materials/Cerberus.mat");
+		AddModel(0, "Models/Cerberus.obj", "Materials/Cerberus.mat", glm::vec3(0.25f));
 
-		//AddSphere(0, "Models/sphere.obj", "Materials/Cobblestone.mat");
-		//AddSphere(1, "Models/sphere.obj", "Materials/Paint.mat");
-		//AddSphere(2, "Models/sphere.obj", "Materials/Bronze.mat");
-		//AddSphere(3, "Models/sphere.obj", "Materials/Cobblestone.mat");
+		//AddModel(0, "Models/sphere.obj", "Materials/Cobblestone.mat");
+		//AddModel(1, "Models/sphere.obj", "Materials/Paint.mat");
+		//AddModel(2, "Models/sphere.obj", "Materials/Bronze.mat");
+		//AddModel(3, "Models/sphere.obj", "Materials/Cobblestone.mat");
 
-		AddPointLight(glm::vec3(+0.0f, +0.0f, +1.0f), glm::vec3(1.0f, 0.0f, 0.0f));
-		AddPointLight(glm::vec3(+0.0f, +0.0f, -1.0f), glm::vec3(1.0f, 1.0f, 0.0f));
+		float Width = 2.0f;
+		AddPointLight(glm::vec3(+0.0f, +0.0f, +Width), glm::vec3(1.0f, 0.0f, 0.0f));
+		AddPointLight(glm::vec3(+0.0f, +0.0f, -Width), glm::vec3(1.0f, 1.0f, 0.0f));
 
-		AddPointLight(glm::vec3(+0.0f, +1.0f, +0.0f), glm::vec3(0.0f, 1.0f, 1.0f));
-		AddPointLight(glm::vec3(+0.0f, -1.0f, +0.0f), glm::vec3(1.0f, 0.0f, 1.0f));
+		AddPointLight(glm::vec3(+0.0f, +Width, +0.0f), glm::vec3(0.0f, 1.0f, 1.0f));
+		AddPointLight(glm::vec3(+0.0f, -Width, +0.0f), glm::vec3(1.0f, 0.0f, 1.0f));
 
 
 		auto AddDirLight = [&](glm::vec3 t_Dir, glm::vec3 t_Color)

--- a/Sandbox/Gameplay/src/SandboxGame.cpp
+++ b/Sandbox/Gameplay/src/SandboxGame.cpp
@@ -143,12 +143,12 @@ namespace Sandbox
 			t0.SetPos(t_Pos);
 		};
 
-		//AddSphere(0, "Models/Cerberus.obj", "Materials/Cerberus.mat");
+		AddSphere(0, "Models/Cerberus.obj", "Materials/Cerberus.mat");
 
-		AddSphere(0, "Models/sphere.obj", "Materials/Cobblestone.mat");
-		AddSphere(1, "Models/sphere.obj", "Materials/Paint.mat");
-		AddSphere(2, "Models/sphere.obj", "Materials/Bronze.mat");
-		AddSphere(3, "Models/sphere.obj", "Materials/Cobblestone.mat");
+		//AddSphere(0, "Models/sphere.obj", "Materials/Cobblestone.mat");
+		//AddSphere(1, "Models/sphere.obj", "Materials/Paint.mat");
+		//AddSphere(2, "Models/sphere.obj", "Materials/Bronze.mat");
+		//AddSphere(3, "Models/sphere.obj", "Materials/Cobblestone.mat");
 
 		AddPointLight(glm::vec3(+0.0f, +0.0f, +1.0f), glm::vec3(1.0f, 0.0f, 0.0f));
 		AddPointLight(glm::vec3(+0.0f, +0.0f, -1.0f), glm::vec3(1.0f, 1.0f, 0.0f));
@@ -166,7 +166,7 @@ namespace Sandbox
 		};
 
 		// Directional Lights
-		//AddDirLight(glm::vec3(+1.0f, -1.0f, -0.5f), glm::vec3(1.0f, 1.0f, 1.0f));
+		AddDirLight(glm::vec3(+1.0f, -1.0f, -0.5f), glm::vec3(1.0f, 1.0f, 1.0f));
 	}
 
 	void Game::GenerateTestMeshes(entt::registry& t_Reg)


### PR DESCRIPTION
## Feature/Issue
Implement the max supported MSAA on a given device. Looks a lot better now that we have aliasing! 

#98 

## Implementation/Solution
A `MultiSampler` class that holds the necessary Images and Memory buffers. Gave the Cubemap, DepthBuffer, and GraphicsPipeline arguments for what level of sampling to use, so that we can very easily change it in the future. 
 
## Screenshots/GIF (if applicable)
![image](https://user-images.githubusercontent.com/14983811/68073221-0ab98c80-fd64-11e9-987f-3bf352065726.png)


## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
