### PR TITLE
Warning cleanup

### DIFF
--- a/FlingEngine/Core/inc/Serilization.h
+++ b/FlingEngine/Core/inc/Serilization.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Platform.h"
+
+// Disable the cereal warnings
+#if FLING_LINUX
+
+#pragma GCC diagnostic ignored "-Wunused-private-field"
+#pragma GCC diagnostic ignored "-Wexceptions"
+
+#elif FLING_WINDOWS
+
+// TODO: MSVC 
+
+#endif
+
+#include <cereal/archives/json.hpp>
+
+
+// Enable the warnings again
+#if FLING_LINUX
+
+#pragma GCC diagnostic ignored "-Wunused-private-field"
+#pragma GCC diagnostic ignored "-Wexceptions"
+
+#elif FLING_WINDOWS
+
+// TODO: MSVC 
+
+#endif

--- a/FlingEngine/Core/src/Engine.cpp
+++ b/FlingEngine/Core/src/Engine.cpp
@@ -51,9 +51,6 @@ namespace Fling
 		// Once the world is initialized it allows the users to add their own components!
 		m_World->Init();
 
-		int FpsFrameCount = 0;
-		float FpsTimeElapsed = 0.0f;
-
 		while(!Renderer.GetCurrentWindow()->ShouldClose())
 		{
             // Update timing

--- a/FlingEngine/Gameplay/inc/Components/Transform.h
+++ b/FlingEngine/Gameplay/inc/Components/Transform.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cereal/archives/json.hpp>
+#include "Serilization.h"
 #include "FlingMath.h"
 
 namespace Fling

--- a/FlingEngine/Gameplay/inc/World.h
+++ b/FlingEngine/Gameplay/inc/World.h
@@ -9,7 +9,7 @@
 #include <fstream>
 
 #include <entt/entity/registry.hpp>
-#include <cereal/archives/json.hpp>
+#include "Serilization.h"
 
 namespace Fling
 {

--- a/FlingEngine/Graphics/inc/Material.h
+++ b/FlingEngine/Graphics/inc/Material.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cereal/archives/json.hpp> // For serialization of a material
 #include "Shader.h"
 #include "Image.h"
 #include "JsonFile.h"

--- a/FlingEngine/Graphics/inc/MeshRenderer.h
+++ b/FlingEngine/Graphics/inc/MeshRenderer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cereal/archives/json.hpp>
+#include "Serilization.h"
 #include "Material.h"
 #include "Model.h"
 #include "Buffer.h"

--- a/FlingEngine/Graphics/src/FlingImgui.cpp
+++ b/FlingEngine/Graphics/src/FlingImgui.cpp
@@ -425,7 +425,6 @@ namespace Fling
             m_vertexBuffer->MapMemory();
         }
 
-        VkDeviceSize indexSize = imDrawData->TotalIdxCount * sizeof(ImDrawIdx);
         if((m_indexBuffer->GetVkBuffer() == VK_NULL_HANDLE) ||
             (m_indexCount < imDrawData->TotalIdxCount))
         {

--- a/FlingEngine/Graphics/src/ImguiDisplay.cpp
+++ b/FlingEngine/Graphics/src/ImguiDisplay.cpp
@@ -14,7 +14,6 @@ namespace Fling
 	{
 		Timing& Timing = Timing::Get();
 		ImGuiIO& io = ImGui::GetIO();
-		ImVec4 clear_color = ImColor(114, 144, 154);
 		
 		ImGui::SetNextWindowSize(ImVec2(200, 200), ImGuiCond_FirstUseEver);
 		ImGui::Begin("Debug");

--- a/FlingEngine/Graphics/src/Shader.cpp
+++ b/FlingEngine/Graphics/src/Shader.cpp
@@ -18,13 +18,7 @@ namespace Fling
     std::shared_ptr<Fling::Shader> Shader::Create(Guid t_ID)
     {
 		const auto& shader = ResourceManager::LoadResource<Shader>(t_ID);
-        bool IsNew = ShaderProgram::Get().AddShader(shader);
-		
-		//if (IsNew)
-		//{
-		//	Renderer::Get().SetFrameBufferHasBeenResized(true);
-		//}
-
+        ShaderProgram::Get().AddShader(shader);
 		return shader;
     }
 


### PR DESCRIPTION
## Feature/Issue
Cleanup warnings from Cereal on Linux

#97 

## Implementation/Solution
Made a `Serialization.h` header and disable the warnings on GCC/Clang

## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
