### PR TITLE
Fix Initializer spelling mistake

### DIFF
--- a/FlingEngine/Graphics/inc/GraphicsHelpers.h
+++ b/FlingEngine/Graphics/inc/GraphicsHelpers.h
@@ -133,7 +133,7 @@ namespace Fling
 
     // Some helpers for Vulkan initialization 
     // Grabbed these from https://github.com/SaschaWillems/Vulkan/tree/master/examples/dynamicuniformbuffer
-    namespace Initalizers
+    namespace Initializers
     {
         VkMappedMemoryRange MappedMemoryRange();
 

--- a/FlingEngine/Graphics/src/Cubemap.cpp
+++ b/FlingEngine/Graphics/src/Cubemap.cpp
@@ -75,40 +75,40 @@ namespace Fling
     void Cubemap::PreparePipeline(VkSampleCountFlagBits t_SampleCount)
     {
         VkPipelineInputAssemblyStateCreateInfo inputAssemblyState =
-            Initalizers::PipelineInputAssemblyStateCreateInfo(
+            Initializers::PipelineInputAssemblyStateCreateInfo(
                 VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
                 0,
                 VK_FALSE);
 
         VkPipelineRasterizationStateCreateInfo rasterizationState =
-            Initalizers::PipelineRasterizationStateCreateInfo(
+            Initializers::PipelineRasterizationStateCreateInfo(
                 VK_POLYGON_MODE_FILL,
                 VK_CULL_MODE_FRONT_BIT,
                 VK_FRONT_FACE_COUNTER_CLOCKWISE,
                 0);
 
         VkPipelineColorBlendAttachmentState blendAttachmentState =
-            Initalizers::PipelineColorBlendAttachmentState(
+            Initializers::PipelineColorBlendAttachmentState(
                 0xf,
                 VK_FALSE);
 
         VkPipelineColorBlendStateCreateInfo colorBlendState =
-            Initalizers::PipelineColorBlendStateCreateInfo(
+            Initializers::PipelineColorBlendStateCreateInfo(
                 1,
                 &blendAttachmentState);
 
         VkPipelineDepthStencilStateCreateInfo depthStencilState =
-            Initalizers::DepthStencilState(
+            Initializers::DepthStencilState(
                 VK_FALSE,
                 VK_FALSE,
                 VK_COMPARE_OP_LESS_OR_EQUAL);
 
         VkPipelineViewportStateCreateInfo viewportState =
-            Initalizers::PipelineViewportStateCreateInfo(
+            Initializers::PipelineViewportStateCreateInfo(
                 1, 1, 0);
 
         VkPipelineMultisampleStateCreateInfo multisampleState =
-            Initalizers::PipelineMultiSampleStateCreateInfo(
+            Initializers::PipelineMultiSampleStateCreateInfo(
                 t_SampleCount,
                 0);
 
@@ -119,7 +119,7 @@ namespace Fling
         };
 
         VkPipelineDynamicStateCreateInfo dynamicState =
-            Initalizers::PipelineDynamicStateCreateInfo(
+            Initializers::PipelineDynamicStateCreateInfo(
                 dynamicStateEnables, 0);
 
         //Pipeline cache 
@@ -143,7 +143,7 @@ namespace Fling
 
         std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages;
 
-        VkGraphicsPipelineCreateInfo pipelineCreateInfo = Initalizers::PipelineCreateInfo(m_PipelineLayout, m_RenderPass, 0);
+        VkGraphicsPipelineCreateInfo pipelineCreateInfo = Initializers::PipelineCreateInfo(m_PipelineLayout, m_RenderPass, 0);
         pipelineCreateInfo.pInputAssemblyState = &inputAssemblyState;
         pipelineCreateInfo.pRasterizationState = &rasterizationState;
         pipelineCreateInfo.pColorBlendState = &colorBlendState;
@@ -304,7 +304,7 @@ namespace Fling
         GraphicsHelpers::EndSingleTimeCommands(copyCmd);
 
         // Create sampler
-        VkSamplerCreateInfo sampler = Initalizers::SamplerCreateInfo();
+        VkSamplerCreateInfo sampler = Initializers::SamplerCreateInfo();
         sampler.magFilter = VK_FILTER_LINEAR;
         sampler.minFilter = VK_FILTER_LINEAR;
         sampler.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
@@ -327,7 +327,7 @@ namespace Fling
             F_LOG_ERROR("Cube failed to create sampler");
         }
 
-        VkImageViewCreateInfo view = Initalizers::ImageViewCreateInfo();
+        VkImageViewCreateInfo view = Initializers::ImageViewCreateInfo();
         view.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
         view.format = m_Format;
         view.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
@@ -346,12 +346,12 @@ namespace Fling
         //Descriptor pools
         std::vector<VkDescriptorPoolSize> poolSizes =
         {
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2)
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2)
         };
 
         VkDescriptorPoolCreateInfo descriptorPoolInfo =
-            Initalizers::DescriptorPoolCreateInfo(poolSizes, 2);
+            Initializers::DescriptorPoolCreateInfo(poolSizes, 2);
 
         if (vkCreateDescriptorPool(m_Device, &descriptorPoolInfo, nullptr, &m_DescriptorPool) != VK_SUCCESS)
         {
@@ -362,19 +362,19 @@ namespace Fling
         std::vector<VkDescriptorSetLayoutBinding> setLayoutBinding =
         {
             //Binding 0 : vertex shader uniform buffer
-            Initalizers::DescriptorSetLayoutBinding(
+            Initializers::DescriptorSetLayoutBinding(
                 VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
                 VK_SHADER_STAGE_VERTEX_BIT,
                 0),
 
-            Initalizers::DescriptorSetLayoutBinding(
+            Initializers::DescriptorSetLayoutBinding(
                 VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                 VK_SHADER_STAGE_FRAGMENT_BIT,
                 1),
         };
 
         VkDescriptorSetLayoutCreateInfo descriptorLayout =
-            Initalizers::DescriptorSetLayoutCreateInfo(
+            Initializers::DescriptorSetLayoutCreateInfo(
                 setLayoutBinding);
 
         if (vkCreateDescriptorSetLayout(m_Device, &descriptorLayout, nullptr, &m_DescriptorSetLayout) != VK_SUCCESS)
@@ -383,7 +383,7 @@ namespace Fling
         }
 
         VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo =
-            Initalizers::PiplineLayoutCreateInfo(
+            Initializers::PiplineLayoutCreateInfo(
                 &m_DescriptorSetLayout,
                 1);
 
@@ -394,13 +394,13 @@ namespace Fling
 
         //Descriptor Sets
         VkDescriptorImageInfo textureDescriptor =
-            Initalizers::DescriptorImageInfo(
+            Initializers::DescriptorImageInfo(
                 m_Sampler,
                 m_Imageview,
                 m_ImageLayout);
 
         VkDescriptorSetAllocateInfo allocInfo =
-            Initalizers::DescriptorSetAllocateInfo(
+            Initializers::DescriptorSetAllocateInfo(
                 m_DescriptorPool,
                 &m_DescriptorSetLayout,
                 1);
@@ -420,14 +420,14 @@ namespace Fling
             std::vector<VkWriteDescriptorSet> writeDescriptorSets =
             {
                 // Binding 0 : Vertex shader uniform buffer
-                Initalizers::WriteDescriptorSet(
+                Initializers::WriteDescriptorSet(
                     m_DescriptorSet,
                     VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
                     0,
                     &m_UniformBufferDescriptor),
 
                 // Binding 1 : Fragment shader cubemap sampler
-                Initalizers::WriteDescriptorSet(
+                Initializers::WriteDescriptorSet(
                     m_DescriptorSet,
                     VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                     1,

--- a/FlingEngine/Graphics/src/FlingImgui.cpp
+++ b/FlingEngine/Graphics/src/FlingImgui.cpp
@@ -228,19 +228,19 @@ namespace Fling
         //Descriptor pool
         std::vector<VkDescriptorPoolSize> poolSizes = 
         {
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_SAMPLER, 1000),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1000),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1000),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1000),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1000),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1000),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1000),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1000),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1000),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_SAMPLER, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1000),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1000),
         };
 
-        VkDescriptorPoolCreateInfo descriptorPoolInfo = Initalizers::DescriptorPoolCreateInfo(poolSizes, 10);
+        VkDescriptorPoolCreateInfo descriptorPoolInfo = Initializers::DescriptorPoolCreateInfo(poolSizes, 10);
 
         if (vkCreateDescriptorPool(logicalDevice, &descriptorPoolInfo, nullptr, &m_descriptorPool) != VK_SUCCESS)
         {
@@ -250,32 +250,32 @@ namespace Fling
         //Descriptor set layout
         std::vector<VkDescriptorSetLayoutBinding> setLayoutBindings =
         {
-            Initalizers::DescriptorSetLayoutBindings(
+            Initializers::DescriptorSetLayoutBindings(
                 VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 
                 VK_SHADER_STAGE_FRAGMENT_BIT, 0),
         };
 
-        VkDescriptorSetLayoutCreateInfo descriptorLayout = Initalizers::DescriptorSetLayoutCreateInfo(setLayoutBindings);
+        VkDescriptorSetLayoutCreateInfo descriptorLayout = Initializers::DescriptorSetLayoutCreateInfo(setLayoutBindings);
         if (vkCreateDescriptorSetLayout(logicalDevice, &descriptorLayout, nullptr, &m_descriptorSetLayout) != VK_SUCCESS)
         {
             F_LOG_ERROR("Could not create descriptor set layout for imgui");
         }
 
         //Descriptor set 
-        VkDescriptorSetAllocateInfo allocInfo = Initalizers::DescriptorSetAllocateInfo(m_descriptorPool, &m_descriptorSetLayout, 1);
+        VkDescriptorSetAllocateInfo allocInfo = Initializers::DescriptorSetAllocateInfo(m_descriptorPool, &m_descriptorSetLayout, 1);
         if (vkAllocateDescriptorSets(logicalDevice, &allocInfo, &m_descriptorSet) != VK_SUCCESS)
         {
             F_LOG_ERROR("Could not allocate descriptor sets for imgui");
         }
 
-        VkDescriptorImageInfo fontDescriptor = Initalizers::DescriptorImageInfo(
+        VkDescriptorImageInfo fontDescriptor = Initializers::DescriptorImageInfo(
             m_sampler,
             m_fontImageView,
             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
         );
 
         std::vector<VkWriteDescriptorSet> writeDescriptorSet = {
-            Initalizers::WriteDescriptorSet(m_descriptorSet, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 0, &fontDescriptor),
+            Initializers::WriteDescriptorSet(m_descriptorSet, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 0, &fontDescriptor),
         };
         
         vkUpdateDescriptorSets(logicalDevice, static_cast<UINT32>(writeDescriptorSet.size()), writeDescriptorSet.data(), 0, nullptr);
@@ -290,8 +290,8 @@ namespace Fling
 
         //Pipeline layout
         //Push constants for UI rendering 
-        VkPushConstantRange pushConstantRange = Initalizers::PushConstantRange(VK_SHADER_STAGE_VERTEX_BIT, sizeof(PushConstBlock), 0);
-        VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = Initalizers::PiplineLayoutCreateInfo(&m_descriptorSetLayout, 1);
+        VkPushConstantRange pushConstantRange = Initializers::PushConstantRange(VK_SHADER_STAGE_VERTEX_BIT, sizeof(PushConstBlock), 0);
+        VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = Initializers::PiplineLayoutCreateInfo(&m_descriptorSetLayout, 1);
         pipelineLayoutCreateInfo.pushConstantRangeCount = 1;
         pipelineLayoutCreateInfo.pPushConstantRanges = &pushConstantRange;
 
@@ -302,10 +302,10 @@ namespace Fling
 
         //Setup graphics pipeline for UI rendering 
         VkPipelineInputAssemblyStateCreateInfo inputAssemblyState =
-            Initalizers::PipelineInputAssemblyStateCreateInfo(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, 0, false);
+            Initializers::PipelineInputAssemblyStateCreateInfo(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, 0, false);
 
         VkPipelineRasterizationStateCreateInfo rasterizationState =
-            Initalizers::PipelineRasterizationStateCreateInfo(VK_POLYGON_MODE_FILL, VK_CULL_MODE_NONE, VK_FRONT_FACE_COUNTER_CLOCKWISE);
+            Initializers::PipelineRasterizationStateCreateInfo(VK_POLYGON_MODE_FILL, VK_CULL_MODE_NONE, VK_FRONT_FACE_COUNTER_CLOCKWISE);
 
         //Enable Blending 
         VkPipelineColorBlendAttachmentState blendAttachmentState = {};
@@ -319,16 +319,16 @@ namespace Fling
         blendAttachmentState.alphaBlendOp = VK_BLEND_OP_ADD;
 
         VkPipelineColorBlendStateCreateInfo colorBlendState = 
-            Initalizers::PipelineColorBlendStateCreateInfo(1, &blendAttachmentState);
+            Initializers::PipelineColorBlendStateCreateInfo(1, &blendAttachmentState);
 
         VkPipelineDepthStencilStateCreateInfo depthStencilState = 
-            Initalizers::DepthStencilState(VK_FALSE, VK_FALSE, VK_COMPARE_OP_LESS_OR_EQUAL);
+            Initializers::DepthStencilState(VK_FALSE, VK_FALSE, VK_COMPARE_OP_LESS_OR_EQUAL);
 
         VkPipelineViewportStateCreateInfo viewportState = 
-            Initalizers::PipelineViewportStateCreateInfo(1, 1, 0);
+            Initializers::PipelineViewportStateCreateInfo(1, 1, 0);
 
         VkPipelineMultisampleStateCreateInfo multisampleState = 
-            Initalizers::PipelineMultiSampleStateCreateInfo(VK_SAMPLE_COUNT_1_BIT);
+            Initializers::PipelineMultiSampleStateCreateInfo(VK_SAMPLE_COUNT_1_BIT);
 
         std::vector<VkDynamicState> dynamicStateEnables = {
             VK_DYNAMIC_STATE_VIEWPORT,
@@ -336,12 +336,12 @@ namespace Fling
         };
 
         VkPipelineDynamicStateCreateInfo dynamicState = 
-            Initalizers::PipelineDynamicStateCreateInfo(dynamicStateEnables);
+            Initializers::PipelineDynamicStateCreateInfo(dynamicStateEnables);
 
         std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages {};
 
         VkGraphicsPipelineCreateInfo pipelineCreateInfo = 
-            Initalizers::PipelineCreateInfo(m_pipelineLayout, m_renderPass);
+            Initializers::PipelineCreateInfo(m_pipelineLayout, m_renderPass);
 
         pipelineCreateInfo.pInputAssemblyState = &inputAssemblyState;
         pipelineCreateInfo.pRasterizationState = &rasterizationState;
@@ -356,17 +356,17 @@ namespace Fling
         // Vertex bindings an attributes based on imgui vertex definitions
         std::vector<VkVertexInputBindingDescription> vertexInputBindings =
         {
-            Initalizers::VertexInputBindingDescription(0, sizeof(ImDrawVert), VK_VERTEX_INPUT_RATE_VERTEX),
+            Initializers::VertexInputBindingDescription(0, sizeof(ImDrawVert), VK_VERTEX_INPUT_RATE_VERTEX),
         };
 
         std::vector<VkVertexInputAttributeDescription> vertexInputAttributes = 
         {
-            Initalizers::VertexInputAttributeDescription(0, 0, VK_FORMAT_R32G32_SFLOAT, offsetof(ImDrawVert, pos)),    // Location 0: Position
-            Initalizers::VertexInputAttributeDescription(0, 1, VK_FORMAT_R32G32_SFLOAT, offsetof(ImDrawVert, uv)),    // Location 1: UV
-            Initalizers::VertexInputAttributeDescription(0, 2, VK_FORMAT_R8G8B8A8_UNORM, offsetof(ImDrawVert, col)),    // Location 0: Color
+            Initializers::VertexInputAttributeDescription(0, 0, VK_FORMAT_R32G32_SFLOAT, offsetof(ImDrawVert, pos)),    // Location 0: Position
+            Initializers::VertexInputAttributeDescription(0, 1, VK_FORMAT_R32G32_SFLOAT, offsetof(ImDrawVert, uv)),    // Location 1: UV
+            Initializers::VertexInputAttributeDescription(0, 2, VK_FORMAT_R8G8B8A8_UNORM, offsetof(ImDrawVert, col)),    // Location 0: Color
         };
 
-        VkPipelineVertexInputStateCreateInfo vertexInputState = Initalizers::PiplineVertexInptStateCreateInfo();
+        VkPipelineVertexInputStateCreateInfo vertexInputState = Initializers::PiplineVertexInptStateCreateInfo();
         vertexInputState.vertexBindingDescriptionCount = static_cast<uint32_t>(vertexInputBindings.size());
         vertexInputState.pVertexBindingDescriptions = vertexInputBindings.data();
         vertexInputState.vertexAttributeDescriptionCount = static_cast<uint32_t>(vertexInputAttributes.size());
@@ -467,7 +467,7 @@ namespace Fling
         float displayWidth = ImGui::GetIO().DisplaySize.x ? ImGui::GetIO().DisplaySize.x : .0001f;
         float displayHeight = ImGui::GetIO().DisplaySize.y ? ImGui::GetIO().DisplaySize.y : .0001f;
 
-        VkViewport viewport = Initalizers::Viewport(
+        VkViewport viewport = Initializers::Viewport(
             displayWidth,
             displayHeight,
             0.0f,

--- a/FlingEngine/Graphics/src/GraphicsHelpers.cpp
+++ b/FlingEngine/Graphics/src/GraphicsHelpers.cpp
@@ -577,7 +577,7 @@ namespace Fling
 
     }    // namespace GraphicsHelpers
 
-    namespace Initalizers
+    namespace Initializers
     {
         VkMappedMemoryRange MappedMemoryRange()
         {

--- a/FlingEngine/Graphics/src/Renderer.cpp
+++ b/FlingEngine/Graphics/src/Renderer.cpp
@@ -484,10 +484,10 @@ namespace Fling
 
             vkCmdBeginRenderPass(m_CommandBuffers[i], &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
             
-            VkViewport viewport = Initalizers::Viewport(static_cast<float>(m_CurrentWindow->GetWidth()), static_cast<float>(m_CurrentWindow->GetHeight()), 0.0f, 1.0f);
+            VkViewport viewport = Initializers::Viewport(static_cast<float>(m_CurrentWindow->GetWidth()), static_cast<float>(m_CurrentWindow->GetHeight()), 0.0f, 1.0f);
             vkCmdSetViewport(m_CommandBuffers[i], 0, 1, &viewport);
 
-            VkRect2D scissor = Initalizers::Rect2D(m_CurrentWindow->GetWidth(), m_CurrentWindow->GetHeight(), 0, 0);
+            VkRect2D scissor = Initializers::Rect2D(m_CurrentWindow->GetWidth(), m_CurrentWindow->GetHeight(), 0, 0);
             vkCmdSetScissor(m_CommandBuffers[i], 0, 1, &scissor);
 
             // Skybox -----------------------------
@@ -626,11 +626,11 @@ namespace Fling
 
         std::vector<VkDescriptorPoolSize> PoolSizes =
         {
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, DescriptorCount),
-			Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, DescriptorCount),
-			Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_SAMPLER, DescriptorCount),
-            Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, DescriptorCount),
-			Initalizers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, DescriptorCount)
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, DescriptorCount),
+			Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, DescriptorCount),
+			Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_SAMPLER, DescriptorCount),
+            Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, DescriptorCount),
+			Initializers::DescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, DescriptorCount)
         };
 
         VkDescriptorPoolCreateInfo PoolInfo = {};
@@ -708,7 +708,7 @@ namespace Fling
 				BufferInfo->buffer = t_MeshRend.m_UniformBuffers[i]->GetVkBuffer();
 				BufferInfo->offset = 0;
 				BufferInfo->range = t_MeshRend.m_UniformBuffers[i]->GetSize();
-				VkWriteDescriptorSet UniformSet = Initalizers::WriteDescriptorSet(
+				VkWriteDescriptorSet UniformSet = Initializers::WriteDescriptorSet(
                     t_MeshRend.m_DescriptorSets[i],
 					VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 					0,
@@ -731,7 +731,7 @@ namespace Fling
 				LightBufferInfo->offset = 0;
 				LightBufferInfo->range = m_Lighting.m_LightingUBOs[i]->GetSize();
 
-				VkWriteDescriptorSet LightUniformSet = Initalizers::WriteDescriptorSet(
+				VkWriteDescriptorSet LightUniformSet = Initializers::WriteDescriptorSet(
                     t_MeshRend.m_DescriptorSets[i],
 					VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 					6,


### PR DESCRIPTION
## Feature/Issue
#108 

## Implementation/Solution
Rename the namespace to `Initializers`


## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
