### PR TITLE
Mesh renderer cleanup

### DIFF
--- a/Assets/Levels/Level_1.json
+++ b/Assets/Levels/Level_1.json
@@ -9,7 +9,7 @@
     "value7": 2,
     "value8": 1,
     "value9": 0,
-    "value10": 8,
+    "value10": 12,
     "value11": 0,
     "value12": {
         "POS_X": -2.0,
@@ -62,10 +62,10 @@
     "value20": {
         "POS_X": 0.0,
         "POS_Y": 0.0,
-        "POS_Z": 1.0,
-        "SCALE_X": 0.10000000149011612,
-        "SCALE_Y": 0.10000000149011612,
-        "SCALE_Z": 0.10000000149011612,
+        "POS_Z": 0.0,
+        "SCALE_X": 1.0,
+        "SCALE_Y": 1.0,
+        "SCALE_Z": 1.0,
         "ROT_X": 0.0,
         "ROT_Y": 0.0,
         "ROT_Z": 0.0
@@ -74,10 +74,10 @@
     "value22": {
         "POS_X": 0.0,
         "POS_Y": 0.0,
-        "POS_Z": -1.0,
-        "SCALE_X": 0.10000000149011612,
-        "SCALE_Y": 0.10000000149011612,
-        "SCALE_Z": 0.10000000149011612,
+        "POS_Z": 0.0,
+        "SCALE_X": 1.0,
+        "SCALE_Y": 1.0,
+        "SCALE_Z": 1.0,
         "ROT_X": 0.0,
         "ROT_Y": 0.0,
         "ROT_Z": 0.0
@@ -85,11 +85,11 @@
     "value23": 6,
     "value24": {
         "POS_X": 0.0,
-        "POS_Y": 1.0,
+        "POS_Y": 0.0,
         "POS_Z": 0.0,
-        "SCALE_X": 0.10000000149011612,
-        "SCALE_Y": 0.10000000149011612,
-        "SCALE_Z": 0.10000000149011612,
+        "SCALE_X": 1.0,
+        "SCALE_Y": 1.0,
+        "SCALE_Z": 1.0,
         "ROT_X": 0.0,
         "ROT_Y": 0.0,
         "ROT_Z": 0.0
@@ -97,59 +97,107 @@
     "value25": 7,
     "value26": {
         "POS_X": 0.0,
-        "POS_Y": -1.0,
+        "POS_Y": 0.0,
         "POS_Z": 0.0,
-        "SCALE_X": 0.10000000149011612,
-        "SCALE_Y": 0.10000000149011612,
-        "SCALE_Z": 0.10000000149011612,
+        "SCALE_X": 1.0,
+        "SCALE_Y": 1.0,
+        "SCALE_Z": 1.0,
         "ROT_X": 0.0,
         "ROT_Y": 0.0,
         "ROT_Z": 0.0
     },
-    "value27": 8,
-    "value28": 0,
-    "value29": {
+    "value27": 4,
+    "value28": {
+        "POS_X": 0.0,
+        "POS_Y": 0.0,
+        "POS_Z": 0.0,
+        "SCALE_X": 1.0,
+        "SCALE_Y": 1.0,
+        "SCALE_Z": 1.0,
+        "ROT_X": 0.0,
+        "ROT_Y": 0.0,
+        "ROT_Z": 0.0
+    },
+    "value29": 5,
+    "value30": {
+        "POS_X": 0.0,
+        "POS_Y": 0.0,
+        "POS_Z": 0.0,
+        "SCALE_X": 1.0,
+        "SCALE_Y": 1.0,
+        "SCALE_Z": 1.0,
+        "ROT_X": 0.0,
+        "ROT_Y": 0.0,
+        "ROT_Z": 0.0
+    },
+    "value31": 6,
+    "value32": {
+        "POS_X": 0.0,
+        "POS_Y": 0.0,
+        "POS_Z": 0.0,
+        "SCALE_X": 1.0,
+        "SCALE_Y": 1.0,
+        "SCALE_Z": 1.0,
+        "ROT_X": 0.0,
+        "ROT_Y": 0.0,
+        "ROT_Z": 0.0
+    },
+    "value33": 7,
+    "value34": {
+        "POS_X": 0.0,
+        "POS_Y": 0.0,
+        "POS_Z": 0.0,
+        "SCALE_X": 1.0,
+        "SCALE_Y": 1.0,
+        "SCALE_Z": 1.0,
+        "ROT_X": 0.0,
+        "ROT_Y": 0.0,
+        "ROT_Z": 0.0
+    },
+    "value35": 8,
+    "value36": 0,
+    "value37": {
         "MESH_NAME": "Models/sphere.obj",
         "MATERIAL_NAME": "Materials/Cobblestone.mat"
     },
-    "value30": 1,
-    "value31": {
+    "value38": 1,
+    "value39": {
         "MESH_NAME": "Models/sphere.obj",
         "MATERIAL_NAME": "Materials/Paint.mat"
     },
-    "value32": 2,
-    "value33": {
+    "value40": 2,
+    "value41": {
         "MESH_NAME": "Models/sphere.obj",
         "MATERIAL_NAME": "Materials/Bronze.mat"
     },
-    "value34": 3,
-    "value35": {
+    "value42": 3,
+    "value43": {
         "MESH_NAME": "Models/sphere.obj",
         "MATERIAL_NAME": "Materials/Cobblestone.mat"
     },
-    "value36": 4,
-    "value37": {
+    "value44": 4,
+    "value45": {
         "MESH_NAME": "Models/sphere.obj",
         "MATERIAL_NAME": "Materials/Default.mat"
     },
-    "value38": 5,
-    "value39": {
+    "value46": 5,
+    "value47": {
         "MESH_NAME": "Models/sphere.obj",
         "MATERIAL_NAME": "Materials/Default.mat"
     },
-    "value40": 6,
-    "value41": {
+    "value48": 6,
+    "value49": {
         "MESH_NAME": "Models/sphere.obj",
         "MATERIAL_NAME": "Materials/Default.mat"
     },
-    "value42": 7,
-    "value43": {
+    "value50": 7,
+    "value51": {
         "MESH_NAME": "Models/sphere.obj",
         "MATERIAL_NAME": "Materials/Default.mat"
     },
-    "value44": 1,
-    "value45": 8,
-    "value46": {
+    "value52": 1,
+    "value53": 8,
+    "value54": {
         "DIFFUSE_X": 1.0,
         "DIFFUSE_Y": 1.0,
         "DIFFUSE_Z": 1.0,
@@ -159,38 +207,38 @@
         "DIRECTION_Z": -0.5,
         "INTENSITY": 1.0
     },
-    "value47": 4,
-    "value48": 4,
-    "value49": {
+    "value55": 4,
+    "value56": 4,
+    "value57": {
         "DIFFUSE_X": 1.0,
         "DIFFUSE_Y": 0.0,
         "DIFFUSE_Z": 0.0,
         "RANGE": 20.0,
         "INTENSITY": 5.0
     },
-    "value50": 5,
-    "value51": {
+    "value58": 5,
+    "value59": {
         "DIFFUSE_X": 1.0,
         "DIFFUSE_Y": 1.0,
         "DIFFUSE_Z": 0.0,
         "RANGE": 20.0,
         "INTENSITY": 5.0
     },
-    "value52": 6,
-    "value53": {
+    "value60": 6,
+    "value61": {
         "DIFFUSE_X": 0.0,
         "DIFFUSE_Y": 1.0,
         "DIFFUSE_Z": 1.0,
         "RANGE": 20.0,
         "INTENSITY": 5.0
     },
-    "value54": 7,
-    "value55": {
+    "value62": 7,
+    "value63": {
         "DIFFUSE_X": 1.0,
         "DIFFUSE_Y": 0.0,
         "DIFFUSE_Z": 1.0,
         "RANGE": 20.0,
         "INTENSITY": 5.0
     },
-    "value56": 0
+    "value64": 0
 }

--- a/FlingEngine/Graphics/inc/Renderer.h
+++ b/FlingEngine/Graphics/inc/Renderer.h
@@ -223,8 +223,6 @@ namespace Fling
         */
         void MeshRendererAdded(entt::entity t_Ent, entt::registry& t_Reg, MeshRenderer& t_MeshRend);
 
-		void MeshRendererReplaced(entt::entity t_Ent, entt::registry& t_Reg);
-
 		void MeshRendererRemoved(entt::entity t_Ent, entt::registry& t_Reg);
 
         /**

--- a/FlingEngine/Graphics/inc/Renderer.h
+++ b/FlingEngine/Graphics/inc/Renderer.h
@@ -223,6 +223,10 @@ namespace Fling
         */
         void MeshRendererAdded(entt::entity t_Ent, entt::registry& t_Reg, MeshRenderer& t_MeshRend);
 
+		void MeshRendererReplaced(entt::entity t_Ent, entt::registry& t_Reg);
+
+		void MeshRendererRemoved(entt::entity t_Ent, entt::registry& t_Reg);
+
         /**
          * @brief   Callback for when a directional light is added to Fling so that we can keep track of how many
          *          we need

--- a/FlingEngine/Graphics/src/Renderer.cpp
+++ b/FlingEngine/Graphics/src/Renderer.cpp
@@ -1094,7 +1094,6 @@ namespace Fling
     {
         // Add any component callbacks that we may need
         m_Registry->on_construct<MeshRenderer>().connect<&Renderer::MeshRendererAdded>(*this);
-		m_Registry->on_replace<MeshRenderer>().connect<&Renderer::MeshRendererReplaced>(*this);
 		m_Registry->on_destroy<MeshRenderer>().connect<&Renderer::MeshRendererRemoved>(*this);
 
         m_Registry->on_construct<DirectionalLight>().connect<&Renderer::DirLightAdded>(*this);

--- a/FlingEngine/Graphics/src/Renderer.cpp
+++ b/FlingEngine/Graphics/src/Renderer.cpp
@@ -717,10 +717,16 @@ namespace Fling
 
 				descriptorWrites.push_back(UniformSet);
 
-                AddImageSampler(t_MeshRend.m_Material->m_Textures.m_AlbedoTexture, 2, t_MeshRend.m_DescriptorSets[i], descriptorWrites);
-                AddImageSampler(t_MeshRend.m_Material->m_Textures.m_NormalTexture, 3, t_MeshRend.m_DescriptorSets[i], descriptorWrites);
-                AddImageSampler(t_MeshRend.m_Material->m_Textures.m_MetalTexture, 4, t_MeshRend.m_DescriptorSets[i], descriptorWrites);
-                AddImageSampler(t_MeshRend.m_Material->m_Textures.m_RoughnessTexture, 5, t_MeshRend.m_DescriptorSets[i], descriptorWrites);
+				Material* Mat = m_DefaultMat.get();
+				if (t_MeshRend.m_Material)
+				{
+					Mat = t_MeshRend.m_Material;
+				}
+
+                AddImageSampler(Mat->m_Textures.m_AlbedoTexture, 2, t_MeshRend.m_DescriptorSets[i], descriptorWrites);
+                AddImageSampler(Mat->m_Textures.m_NormalTexture, 3, t_MeshRend.m_DescriptorSets[i], descriptorWrites);
+                AddImageSampler(Mat->m_Textures.m_MetalTexture, 4, t_MeshRend.m_DescriptorSets[i], descriptorWrites);
+                AddImageSampler(Mat->m_Textures.m_RoughnessTexture, 5, t_MeshRend.m_DescriptorSets[i], descriptorWrites);
 				AddImageSampler(m_BRDFLookupTexture.get(), 7, t_MeshRend.m_DescriptorSets[i], descriptorWrites);
 				// TODO: Ambient Occlusion Map
 
@@ -1088,6 +1094,9 @@ namespace Fling
     {
         // Add any component callbacks that we may need
         m_Registry->on_construct<MeshRenderer>().connect<&Renderer::MeshRendererAdded>(*this);
+		m_Registry->on_replace<MeshRenderer>().connect<&Renderer::MeshRendererReplaced>(*this);
+		m_Registry->on_destroy<MeshRenderer>().connect<&Renderer::MeshRendererRemoved>(*this);
+
         m_Registry->on_construct<DirectionalLight>().connect<&Renderer::DirLightAdded>(*this);
 		m_Registry->on_construct<PointLight>().connect<&Renderer::PointLightAdded>(*this);
     }
@@ -1106,6 +1115,17 @@ namespace Fling
 
 		SetFrameBufferHasBeenResized(true);
     }
+
+	void Renderer::MeshRendererReplaced(entt::entity t_Ent, entt::registry& t_Reg)
+	{
+		F_LOG_TRACE("Mesh renderer at ID {} has been replaced!", static_cast<UINT64>(t_Ent));
+	}
+
+	void Renderer::MeshRendererRemoved(entt::entity t_Ent, entt::registry& t_Reg)
+	{
+		F_LOG_TRACE("Mesh renderer at ID {} has been Removed!", static_cast<UINT64>(t_Ent));
+		SetFrameBufferHasBeenResized(true);
+	}
 
     void Renderer::DirLightAdded(entt::entity t_Ent, entt::registry& t_Reg, DirectionalLight& t_Light)
     {

--- a/FlingEngine/Graphics/src/Renderer.cpp
+++ b/FlingEngine/Graphics/src/Renderer.cpp
@@ -1116,14 +1116,8 @@ namespace Fling
 		SetFrameBufferHasBeenResized(true);
     }
 
-	void Renderer::MeshRendererReplaced(entt::entity t_Ent, entt::registry& t_Reg)
-	{
-		F_LOG_TRACE("Mesh renderer at ID {} has been replaced!", static_cast<UINT64>(t_Ent));
-	}
-
 	void Renderer::MeshRendererRemoved(entt::entity t_Ent, entt::registry& t_Reg)
 	{
-		F_LOG_TRACE("Mesh renderer at ID {} has been Removed!", static_cast<UINT64>(t_Ent));
 		SetFrameBufferHasBeenResized(true);
 	}
 

--- a/Sandbox/Gameplay/src/SandboxGame.cpp
+++ b/Sandbox/Gameplay/src/SandboxGame.cpp
@@ -153,16 +153,16 @@ namespace Sandbox
 		//AddModel(0, "Models/Cerberus.obj", "Materials/Cerberus.mat", glm::vec3(0.25f));
 
 		AddModel(0, "Models/sphere.obj", "Materials/Cobblestone.mat");
-		AddModel(1, "Models/sphere.obj", "Materials/Paint.mat");
-		AddModel(2, "Models/sphere.obj", "Materials/Bronze.mat");
-		AddModel(3, "Models/sphere.obj", "Materials/Cobblestone.mat");
+		//AddModel(1, "Models/sphere.obj", "Materials/Paint.mat");
+		//AddModel(2, "Models/sphere.obj", "Materials/Bronze.mat");
+		//AddModel(3, "Models/sphere.obj", "Materials/Cobblestone.mat");
 
 		float Width = 2.0f;
-		AddPointLight(glm::vec3(+0.0f, +0.0f, +Width), glm::vec3(1.0f, 0.0f, 0.0f));
-		AddPointLight(glm::vec3(+0.0f, +0.0f, -Width), glm::vec3(1.0f, 1.0f, 0.0f));
-
-		AddPointLight(glm::vec3(+0.0f, +Width, +0.0f), glm::vec3(0.0f, 1.0f, 1.0f));
-		AddPointLight(glm::vec3(+0.0f, -Width, +0.0f), glm::vec3(1.0f, 0.0f, 1.0f));
+		//AddPointLight(glm::vec3(+0.0f, +0.0f, +Width), glm::vec3(1.0f, 0.0f, 0.0f));
+		//AddPointLight(glm::vec3(+0.0f, +0.0f, -Width), glm::vec3(1.0f, 1.0f, 0.0f));
+		//
+		//AddPointLight(glm::vec3(+0.0f, +Width, +0.0f), glm::vec3(0.0f, 1.0f, 1.0f));
+		//AddPointLight(glm::vec3(+0.0f, -Width, +0.0f), glm::vec3(1.0f, 0.0f, 1.0f));
 
 
 		auto AddDirLight = [&](glm::vec3 t_Dir, glm::vec3 t_Color)


### PR DESCRIPTION
## Feature/Issue
#100 

## Implementation/Solution
Add a callback to the `on_destroy` method of mesh renderers, so that the correct cleanup happens 

## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
