### PR TITLE
Add a Free List for easy use of a pool allocator

### DIFF
--- a/FlingEngine/Utils/inc/FreeList.h
+++ b/FlingEngine/Utils/inc/FreeList.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace Fling
+{
+    /**
+     * @brief   Helpful for allocating/freeing objects of a certain
+     *          size which have to be created/destroeyed dynamically
+     * 
+     * @see     https://blog.molecular-matters.com/2012/09/17/memory-allocation-strategies-a-pool-allocator/
+     */
+    class FreeList
+    {
+    public:
+        FreeList(void* t_Start, void* t_End, size_t t_ElmSize, size_t t_NumElms, size_t t_Alignment = 8, size_t t_Offset = 0);
+
+        inline void* Obtain();
+
+        inline void Return(void* t_Ptr);
+
+    private:
+        /** Alias in memory to the next available block. Nullptr if none are available */
+        FreeList* m_Next = nullptr;
+    };
+}   // namespace Fling

--- a/FlingEngine/Utils/inc/FreeList.h
+++ b/FlingEngine/Utils/inc/FreeList.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <stdlib.h>     // size_t
+#include <assert.h>
+
+#include "FlingExports.h"
+
 namespace Fling
 {
     /**
@@ -8,17 +13,57 @@ namespace Fling
      * 
      * @see     https://blog.molecular-matters.com/2012/09/17/memory-allocation-strategies-a-pool-allocator/
      */
-    class FreeList
+    class FLING_API FreeList
     {
     public:
-        FreeList(void* t_Start, void* t_End, size_t t_ElmSize, size_t t_NumElms, size_t t_Alignment = 8, size_t t_Offset = 0);
 
+        /**
+         * @brief Construct a new Free List object
+         * 
+         * @param t_Start       Start of the memory block to use for this free list
+         * @param t_End         End of the memory block to use for this free list
+         * @param t_ElmSize     Size of an "element" that this list will be used for
+         * @param t_NumElms     Number of elements to store inside this free list
+         * @param t_Alignment   Alignment of the element (default = 8)
+         * @param t_Offset      Offset of the element (default = 0)
+         */
+        FreeList(void* t_Start, void* t_End, size_t t_ElmSize, size_t t_Alignment = 8, size_t t_Offset = 0);
+
+        /**
+         * @brief         Obtain a chunk of memory of the size and alignment that this list was created with
+         * 
+         * @return void*    nullptr if no memory available
+         */
         inline void* Obtain();
 
+        /**
+         * @brief   Return a block of memory to the free list. Memory can be returned in any order
+         */
         inline void Return(void* t_Ptr);
 
     private:
+    
         /** Alias in memory to the next available block. Nullptr if none are available */
         FreeList* m_Next = nullptr;
     };
+
+	inline void* FreeList::Obtain()
+	{
+		if (m_Next == nullptr)
+		{
+			return nullptr;
+		}
+
+		FreeList* head = m_Next;
+		m_Next = head->m_Next;
+		return head;
+	}
+
+	inline void FreeList::Return(void* t_Ptr)
+	{
+		FreeList* head = static_cast<FreeList*>(t_Ptr);
+		head->m_Next = m_Next;
+		m_Next = head;
+	}
+
 }   // namespace Fling

--- a/FlingEngine/Utils/inc/FreeList.h
+++ b/FlingEngine/Utils/inc/FreeList.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdlib.h>     // size_t
+#include <cstddef>		//std::ptrdiff_t
 #include <assert.h>
 
 #include "FlingExports.h"
@@ -34,7 +35,7 @@ namespace Fling
          * 
          * @return void*    nullptr if no memory available
          */
-        inline void* Obtain();
+        inline void* Obtain() noexcept;
 
         /**
          * @brief   Return a block of memory to the free list. Memory can be returned in any order
@@ -47,7 +48,7 @@ namespace Fling
         FreeList* m_Next = nullptr;
     };
 
-	inline void* FreeList::Obtain()
+	inline void* FreeList::Obtain() noexcept
 	{
 		if (m_Next == nullptr)
 		{

--- a/FlingEngine/Utils/src/FreeList.cpp
+++ b/FlingEngine/Utils/src/FreeList.cpp
@@ -1,0 +1,50 @@
+#include "FreeList.h"
+
+namespace Fling
+{
+    FreeList::FreeList(void* t_Start, void* t_End, size_t elmSize, size_t t_NumElms, size_t alignment, size_t offset)
+    {
+        union
+        {
+            void* as_void;
+            char* as_char;
+            FreeList* as_self;
+        };
+
+        as_void = t_Start;
+
+        // assume as_self points to the first entry in the free list
+        m_Next = as_self;
+        as_char += elmSize;
+
+        // initialize the free list - make every m_next of each element point to the next element in the list
+        FreeList* runner = m_Next;
+        for (size_t i = 1; i < t_NumElms; ++i)
+        {
+            runner->m_Next = as_self;
+            runner = as_self;
+            as_char += elmSize;
+        }
+        
+        runner->m_Next = nullptr;
+    }
+
+    void* FreeList::Obtain()
+    {
+        if(m_Next == nullptr)
+        {
+            return nullptr;
+        }
+
+        FreeList* head = m_Next;
+        m_Next = head->m_Next;
+        return head;
+    }
+
+    void FreeList::Return(void* t_Ptr)
+    {
+        FreeList* head = static_cast<FreeList*>(t_Ptr);
+        head->m_Next = m_Next;
+        m_Next = head;
+    }
+}

--- a/FlingEngine/Utils/src/FreeList.cpp
+++ b/FlingEngine/Utils/src/FreeList.cpp
@@ -2,7 +2,7 @@
 
 namespace Fling
 {
-    FreeList::FreeList(void* t_Start, void* t_End, size_t elmSize, size_t t_NumElms, size_t alignment, size_t offset)
+    FreeList::FreeList(void* t_Start, void* t_End, size_t t_ElmSize, size_t alignment, size_t offset)
     {
         union
         {
@@ -15,36 +15,23 @@ namespace Fling
 
         // assume as_self points to the first entry in the free list
         m_Next = as_self;
-        as_char += elmSize;
+        as_char += t_ElmSize;
 
         // initialize the free list - make every m_next of each element point to the next element in the list
         FreeList* runner = m_Next;
-        for (size_t i = 1; i < t_NumElms; ++i)
+
+		// Calculate the number of elements will fit in this buffer
+		ptrdiff_t bufferSize = ((const char*)t_End - (const char*)t_Start);
+		assert(bufferSize > 0);
+		size_t NumElements = bufferSize / t_ElmSize;
+
+        for (size_t i = 1; i < NumElements; ++i)
         {
             runner->m_Next = as_self;
             runner = as_self;
-            as_char += elmSize;
+            as_char += t_ElmSize;
         }
         
         runner->m_Next = nullptr;
-    }
-
-    void* FreeList::Obtain()
-    {
-        if(m_Next == nullptr)
-        {
-            return nullptr;
-        }
-
-        FreeList* head = m_Next;
-        m_Next = head->m_Next;
-        return head;
-    }
-
-    void FreeList::Return(void* t_Ptr)
-    {
-        FreeList* head = static_cast<FreeList*>(t_Ptr);
-        head->m_Next = m_Next;
-        m_Next = head;
     }
 }

--- a/FlingEngine/Utils/src/FreeList.cpp
+++ b/FlingEngine/Utils/src/FreeList.cpp
@@ -21,7 +21,7 @@ namespace Fling
         FreeList* runner = m_Next;
 
 		// Calculate the number of elements will fit in this buffer
-		ptrdiff_t bufferSize = ((const char*)t_End - (const char*)t_Start);
+		std::ptrdiff_t bufferSize = ((const char*)t_End - (const char*)t_Start);
 		assert(bufferSize > 0);
 		size_t NumElements = bufferSize / t_ElmSize;
 

--- a/FlingTests/src/UtilsTests.cpp
+++ b/FlingTests/src/UtilsTests.cpp
@@ -6,6 +6,7 @@
 #include "Singleton.hpp"
 #include "Random.h"
 #include "Logger.h"
+#include "FreeList.h"
 
 TEST_CASE("Timing", "[utils]")
 {
@@ -48,4 +49,22 @@ TEST_CASE("Logger", "[utils]")
     {
 		REQUIRE(Logger::GetCurrentLogFile() != nullptr);
     }
+}
+
+TEST_CASE("Free List", "[utils]")
+{
+	using namespace Fling;
+
+    char buf[1024] = {};
+
+    FreeList freelist(buf, buf + 1024, 32, 8, 0);
+
+    void* obj0 = freelist.Obtain();
+	REQUIRE(obj0 != nullptr);
+
+    void* obj1 = freelist.Obtain();	
+	REQUIRE(obj1 != nullptr);
+
+	freelist.Return(obj1);
+	freelist.Return(obj0);
 }


### PR DESCRIPTION
## Feature/Issue
#53 

Added a `FreeList` class which will allow for O(1) allocations. 

## Implementation/Solution
Given a buffer, a free list can be used to obtain and return objects of a certain size, alignment, and offset. We give total user control in this situation, because it's recommended you create multiple pools for objects of different sizes and alignments that best fit your use case. 

Added a few new unit tests to ensure functionality. 

## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
