### PR TITLE
Initalzie the DT to 1 over 60 instead of 0

### DIFF
--- a/FlingEngine/Core/src/Input/LinuxInput.cpp
+++ b/FlingEngine/Core/src/Input/LinuxInput.cpp
@@ -160,6 +160,23 @@ namespace Fling
 				InputMapping.second();
 			}
 		}
+
+#if WITH_IMGUI
+		// Update imgui mouse events and timings
+		ImGuiIO& io = ImGui::GetIO();
+
+		DesktopWindow* Window = static_cast<DesktopWindow*>(Renderer::Get().GetCurrentWindow());
+
+		io.DisplaySize = ImVec2(
+			static_cast<float>(Window->GetWidth()),
+			static_cast<float>(Window->GetHeight())
+		);
+
+		io.MousePos = ImVec2(Input::GetMousePos().X, Input::GetMousePos().Y);
+
+		io.MouseDown[0] = Input::IsMouseDown(KeyNames::FL_MOUSE_BUTTON_1);
+		io.MouseDown[1] = Input::IsMouseDown(KeyNames::FL_MOUSE_BUTTON_2);
+#endif
 	}
 	
 	bool LinuxInput::IsKeyDownImpl(const std::string& t_KeyName)

--- a/FlingEngine/Core/src/Input/WindowsInput.cpp
+++ b/FlingEngine/Core/src/Input/WindowsInput.cpp
@@ -161,6 +161,23 @@ namespace Fling
 				InputMapping.second();
 			}
 		}
+
+#if WITH_IMGUI
+		// Update imgui mouse events and timings
+		ImGuiIO& io = ImGui::GetIO();
+
+		DesktopWindow* Window = static_cast<DesktopWindow*>(Renderer::Get().GetCurrentWindow());
+
+		io.DisplaySize = ImVec2(
+			static_cast<float>(Window->GetWidth()),
+			static_cast<float>(Window->GetHeight())
+		);
+
+		io.MousePos = ImVec2(Input::GetMousePos().X, Input::GetMousePos().Y);
+
+		io.MouseDown[0] = Input::IsMouseDown(KeyNames::FL_MOUSE_BUTTON_1);
+		io.MouseDown[1] = Input::IsMouseDown(KeyNames::FL_MOUSE_BUTTON_2);
+#endif
 	}
 
 	bool WindowsInput::IsKeyDownImpl(const std::string& t_KeyName)

--- a/FlingEngine/Graphics/inc/Renderer.h
+++ b/FlingEngine/Graphics/inc/Renderer.h
@@ -154,7 +154,6 @@ namespace Fling
         
         /// Init imgui context 
         void InitImgui();
-        void UpdateImguiIO();
 
         /**
         * @brief Set any component type callbacks needed for the rendering pipeline

--- a/FlingEngine/Graphics/src/Renderer.cpp
+++ b/FlingEngine/Graphics/src/Renderer.cpp
@@ -139,24 +139,6 @@ namespace Fling
 		}
     }
 
-    void Renderer::UpdateImguiIO()
-    {
-#if WITH_IMGUI
-        // Update imgui mouse events and timings
-        ImGuiIO& io = ImGui::GetIO();
-
-        io.DisplaySize = ImVec2(
-            static_cast<float>(m_CurrentWindow->GetWidth()),
-            static_cast<float>(m_CurrentWindow->GetHeight()));
-
-        io.DeltaTime = Timing::Get().GetDeltaTime();
-        io.MousePos = ImVec2(Input::GetMousePos().X, Input::GetMousePos().Y);
-
-        io.MouseDown[0] = Input::IsMouseDown(KeyNames::FL_MOUSE_BUTTON_1);
-        io.MouseDown[1] = Input::IsMouseDown(KeyNames::FL_MOUSE_BUTTON_2);
-#endif
-    }
-
     void Renderer::CreateRenderPass()
     {
 		assert(m_MsaaSampler && m_SwapChain);
@@ -820,9 +802,7 @@ namespace Fling
         m_CurrentWindow->Update();
 
         m_camera->Update(DeltaTime);
-#if WITH_IMGUI
-		UpdateImguiIO();
-#endif
+
     }
 
     void Renderer::DrawFrame(entt::registry& t_Reg, float DeltaTime)

--- a/FlingEngine/Utils/inc/Timing.h
+++ b/FlingEngine/Utils/inc/Timing.h
@@ -82,7 +82,9 @@ namespace Fling
 		float FLING_API GetFrameTime() const { return 1000.0f / static_cast<float>(m_fpsFrameCount); }
 
 	private:
-		float m_deltaTime = 0.0f;
+
+		// Initialize delta time at 60 FPS to avoid an ImGUI assertion
+		float m_deltaTime = 1.0f / 60.0f;
 
 		double m_lastFrameStartTime = 0.0;
 		float m_frameStartTimef = 0.0f;

--- a/FlingEngine/Utils/src/Timing.cpp
+++ b/FlingEngine/Utils/src/Timing.cpp
@@ -15,13 +15,6 @@ namespace Fling
 
 		m_deltaTime = (float)( currentTime - m_lastFrameStartTime );
 
-		m_lastFrameStartTime = currentTime;
-		m_frameStartTimef = static_cast<float> ( m_lastFrameStartTime );
-
-	}
-
-	float Timing::GetDeltaTime()
-	{
 		// Calculate a fall back delta time in case the engine ever gets out of sync
 		const static float FallbackDeltaTime = 1.0f / 60.0f;
 		const static float MaxDeltaTime = 1.0f;
@@ -31,7 +24,15 @@ namespace Fling
 		if (m_deltaTime >= MaxDeltaTime)
 		{
 			m_deltaTime = FallbackDeltaTime;
-		} 
+		}
+
+		m_lastFrameStartTime = currentTime;
+		m_frameStartTimef = static_cast<float> ( m_lastFrameStartTime );
+
+	}
+
+	float Timing::GetDeltaTime()
+	{
 		return m_deltaTime;	
 	}
 


### PR DESCRIPTION
## Feature/Issue
Sometimes in `Debug` ImGui would get an uninitialized delta time (0.0f). To fix this I initialize `Timing::m_DeltaTime` to be 1/60, and move the clamping of delta time to the `UpdateTimer` method

Tested on Windows x64 in Debug to ensure the same repro environment. 

## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
