### PR TITLE
Point light debug fix

### DIFF
--- a/FlingEngine/Graphics/src/Renderer.cpp
+++ b/FlingEngine/Graphics/src/Renderer.cpp
@@ -1135,15 +1135,31 @@ namespace Fling
 		F_LOG_TRACE("Point Light added!");
 		++m_Lighting.m_CurrentPointLights;
 
-		Transform& t = t_Reg.assign<Transform>(t_Ent);
+		// Ensure that we have a transform component before adding a light
+		if (!t_Reg.has<Transform>(t_Ent))
+		{
+			t_Reg.assign<Transform>(t_Ent);
+		}
+
+		Transform& t = t_Reg.get<Transform>(t_Ent);
 
 #if FLING_DEBUG
 		// Make a cute little debug mesh on a point light	
 		t.SetScale(glm::vec3{ 0.1f });
-		t_Reg.assign<MeshRenderer>(t_Ent, "Models/sphere.obj");
+		static std::string PointLightMesh = "Models/sphere.obj";
+		if (!t_Reg.has<MeshRenderer>(t_Ent))
+		{
+			t_Reg.assign<MeshRenderer>(t_Ent, PointLightMesh);
+		}
+
+		// Ensure that we have the proper point light mesh on for a nice little gizmo
+		MeshRenderer& m = t_Reg.get<MeshRenderer>(t_Ent);
+		m.LoadModelFromPath(PointLightMesh);
+		m.LoadMaterialFromPath("Materials/Default.mat");
+
 #endif	// FLING_DEBUG
 
-		if (m_Lighting.m_CurrentPointLights> Lighting::MaxPointLights)
+		if (m_Lighting.m_CurrentPointLights > Lighting::MaxPointLights)
 		{
 			F_LOG_WARN("You have enterer more then the max support point lights of Fling!");
 		}


### PR DESCRIPTION
## Feature/Issue
#118 

## Implementation/Solution
Only add transforms and mesh renderers if the entity does not already have them. 

## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
