### PR TITLE
Some warning cleanup and memory leak fix on script comonents

### DIFF
--- a/FlingEngine/Gameplay/inc/World.inl
+++ b/FlingEngine/Gameplay/inc/World.inl
@@ -5,10 +5,11 @@
 #include "MeshRenderer.h"
 #include "Lighting/DirectionalLight.hpp"
 #include "Lighting/PointLight.hpp"
+#include "ScriptComponent.h"
 
 // Definition of what world components we want to serialize to the disk when
 // saving and loading a scene
-#define WORLD_COMPONENTS Fling::Transform, MeshRenderer, DirectionalLight, PointLight
+#define WORLD_COMPONENTS Fling::Transform, MeshRenderer, DirectionalLight, PointLight, Fling::ScriptComponent
 
 namespace Fling
 {

--- a/FlingEngine/Graphics/inc/VulkanApp.h
+++ b/FlingEngine/Graphics/inc/VulkanApp.h
@@ -126,6 +126,8 @@ namespace Fling
 		/** Handle to the surface extension used to interact with the windows system */
 		VkSurfaceKHR m_Surface = VK_NULL_HANDLE;
 		
+		/** The index of the current frame in flight. This is controlled with the in flight fences 
+		and is updated every Update of the vulkan app. */
 		size_t CurrentFrameIndex = 0;
 
 		// Command Buffer pool

--- a/FlingEngine/Resources/inc/File.h
+++ b/FlingEngine/Resources/inc/File.h
@@ -14,6 +14,8 @@ namespace Fling
     {
     public:
 
+		static std::shared_ptr<Fling::File> Create(Guid t_ID);
+
         /**
          * @brief Construct a new File object
          * 

--- a/FlingEngine/Resources/src/File.cpp
+++ b/FlingEngine/Resources/src/File.cpp
@@ -1,8 +1,14 @@
 #include "pch.h"
 #include "File.h"
+#include "ResourceManager.h"
 
 namespace Fling
 {
+    std::shared_ptr<Fling::File> File::Create(Guid t_ID)
+    {
+		return ResourceManager::LoadResource<Fling::File>(t_ID);
+    }
+
     File::File(Guid t_ID)
         : Resource(t_ID)
     {

--- a/FlingEngine/Resources/src/HDRImage.cpp
+++ b/FlingEngine/Resources/src/HDRImage.cpp
@@ -47,7 +47,6 @@ namespace Fling
             0
         );
 
-        UINT32 HDRTexture;
         m_Width = static_cast<UINT32>(Width);
         m_Height = static_cast<UINT32>(Height);
         m_MipLevels = static_cast<UINT32>(std::floor(std::log2(std::max(m_Width, m_Height)))) + 1;

--- a/FlingEngine/Scripting/inc/ScriptComponent.h
+++ b/FlingEngine/Scripting/inc/ScriptComponent.h
@@ -1,7 +1,8 @@
 #if WITH_LUA
+
 #pragma once
-#include "pch.h"
 #include "File.h"
+#include "Serilization.h"
 
 namespace Fling
 {
@@ -18,11 +19,14 @@ namespace Fling
 		* @param t_FilePath		The path to the lua script file
 		*/
 		ScriptComponent(const std::string t_FilePath);
+		
+		/** Default ctor for serialization */
+		ScriptComponent() = default;
 
 		/**
 		* @brief Destructor
 		*/
-		~ScriptComponent();
+		~ScriptComponent() = default;
 
 		/**
 		* @brief Getter for the lua script file reference
@@ -31,10 +35,45 @@ namespace Fling
 		*/
 		inline File* GetScriptFile() { return m_ScriptFile; }
 
+		template<class Archive>
+		void save(Archive& t_Archive) const;
+
+		template<class Archive>
+		void load(Archive& t_Archive);
+
 	private:
 
 		//A reference to the script file
 		File* m_ScriptFile = nullptr;
 	};
+
+	/** Serialization to an Archive */
+	template<class Archive>
+	inline void ScriptComponent::save(Archive& t_Archive) const
+	{
+		std::string ScriptPath = "INVALID_LUA_PATH";
+
+		if (m_ScriptFile)
+		{
+			ScriptPath = m_ScriptFile->GetGuidString();
+		}
+
+		t_Archive(
+			cereal::make_nvp("SCRIPT_PATH", ScriptPath)
+		);
+	}
+
+	template<class Archive>
+	inline void ScriptComponent::load(Archive& t_Archive)
+	{
+		std::string ScriptPath = "";
+
+		t_Archive(
+			cereal::make_nvp("SCRIPT_PATH", ScriptPath)
+		);
+
+		m_ScriptFile = File::Create(HS(ScriptPath.c_str())).get();
+	}
 }
-#endif
+
+#endif	// WITH_LUA

--- a/FlingEngine/Scripting/src/ScriptComponent.cpp
+++ b/FlingEngine/Scripting/src/ScriptComponent.cpp
@@ -7,11 +7,7 @@ namespace Fling
 	ScriptComponent::ScriptComponent(const std::string t_FilePath)
 	{
 		//Convert the filepath into a GUID
-		m_ScriptFile = new File(entt::hashed_string{ t_FilePath.c_str() });
-	}
-
-	ScriptComponent::~ScriptComponent()
-	{
+		m_ScriptFile = File::Create(HS(t_FilePath.c_str())).get();
 	}
 }
 #endif

--- a/FlingEngine/Utils/inc/StackAllocator.h
+++ b/FlingEngine/Utils/inc/StackAllocator.h
@@ -29,11 +29,11 @@ namespace Fling
          * @brief 
          * 
          * @param t_Size        Size of the block of memory 
-         * @param t_Alignment   Alignment of the element (perfer sizes are a power of 2)
-         * @param t_Offset      Offset of the element
+         * @param t_Alignment   Alignment of the element (Default = 8)
+         * @param t_Offset      Offset of the element (Default = 0)
          * @return void*        Obtain a chunk of memory of the size, alignment, and offset (asserts when we exceed preallocated size) 
          */
-        void* Allocate(size_t t_Size, size_t t_Alignment, size_t t_Offset);
+        void* Allocate(size_t t_Size, size_t t_Alignment = 0, size_t t_Offset = 0);
 
         /**
          * @brief Returns a block of memory to the stack in a LIFO manner 


### PR DESCRIPTION
## Feature/Issue
#133 

## Implementation/Solution
Made the script properly use a `shared_ptr` type for the script file. 
Added save/load serialization to the `ScriptComponent` 
Cleaned up some other misc. warnings while I was in here

## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
