### PR TITLE
Fix clang on windows and add a build-clang script for cmake ease of use

### DIFF
--- a/FlingEngine/CMakeLists.txt
+++ b/FlingEngine/CMakeLists.txt
@@ -81,15 +81,13 @@ if ( NOT WIN32 )
     message( STATUS "Added pthread!" )
 endif()
 
-# we need to link filesystem on GCC 8+
-if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
-    set( LINK_LIBS ${LINK_LIBS} stdc++fs )
-    message( STATUS "Added filesytem link!" )
-endif()
-
+# We need to link the std::filesystem on clang/GNU, but the windows version of 
+# Clang doesn't have this lib
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    if(NOT WIN32)
     set( LINK_LIBS ${LINK_LIBS} stdc++fs )
-    message( STATUS "Added filesytem link (Clang)!" )
+        message( STATUS "Added filesytem link (Clang)!" )
+    endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set( LINK_LIBS ${LINK_LIBS} stdc++fs )
     message( STATUS "Added filesytem link (GNU)!" )

--- a/build-vs-clang.sh
+++ b/build-vs-clang.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo Building Fling Engine in Release mode...
+
+# Create the build folders if they are not created already
+mkdir build -p
+
+# Make sure that we have all external libraries that we need
+git submodule update --init --recursive
+
+# Run cmake!
+cmake . -G "Visual Studio 16 2019" -T "clang-cl" -A x64 -B build


### PR DESCRIPTION
## Feature/Issue
Fix clang compile errors on windows with stdfs
#158 

## Implementation/Solution
Do not incorrectly include stdfs on windows via cmake

## Dependencies (if any?)
 - Clang
 
## Screenshots/GIF (if applicable)


## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
