### PR TITLE
Cmake refactor

### DIFF
--- a/CMake/FlingCompilerFlag.cmake
+++ b/CMake/FlingCompilerFlag.cmake
@@ -1,0 +1,23 @@
+# Just a small macro that will make a CMake project option, and 
+# then add a #define associated to that set to the value of 0 or 1
+# depending on if the option is on or not
+
+
+MACRO( FLING_Compiler_Flag FlagName DefineName Description DefaultValue )
+
+    OPTION( ${FlagName} ${Description} ${DefaultValue} ) 
+
+    # If the option is enabled, then define the value to 1
+    IF( ${FlagName} )
+        add_compile_definitions( ${DefineName}=1)
+        message( Status "${DefineName}=1" )
+    # otherwise, set it to false
+    else()
+        add_compile_definitions( ${DefineName}=0)
+        message( Status "${DefineName}=0" )  
+    endif()    
+
+    #target_compile_definitions(trie_io_test PRIVATE UNIT_TESTING=1 IO_TEST=1)
+
+
+ENDMACRO(FLING_Compiler_Flag)

--- a/CMake/FlingCompilerFlag.cmake
+++ b/CMake/FlingCompilerFlag.cmake
@@ -1,8 +1,6 @@
 # Just a small macro that will make a CMake project option, and 
 # then add a #define associated to that set to the value of 0 or 1
 # depending on if the option is on or not
-
-
 MACRO( FLING_Compiler_Flag FlagName DefineName Description DefaultValue )
 
     OPTION( ${FlagName} ${Description} ${DefaultValue} ) 
@@ -15,9 +13,6 @@ MACRO( FLING_Compiler_Flag FlagName DefineName Description DefaultValue )
     else()
         add_compile_definitions( ${DefineName}=0)
         message( Status "${DefineName}=0" )  
-    endif()    
-
-    #target_compile_definitions(trie_io_test PRIVATE UNIT_TESTING=1 IO_TEST=1)
-
+    endif()
 
 ENDMACRO(FLING_Compiler_Flag)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required ( VERSION 3.11.0 )
 set( CMAKE_SUPPRESS_REGENERATION true )
 set( CMAKE_INSTALL_MESSAGE LAZY )   # Skips update to date messages
 
-project ( "FlingEngine" )
+project ( "FlingEngine" VERSION 1.0 )
 
 # Generated folder used for Cmake generated files
 set( GENERATED_INC_FOLDER ${CMAKE_BINARY_DIR}/Generated )
@@ -24,7 +24,6 @@ OPTION( DEFINE_SHIPPING "DEFINE_SHIPPING configuration will change asset paths t
 OPTION( WITH_IMGUI_FLAG "WITH_IMGUI_FLAG will enable or disable the addition of IMGUI to the rendering pipeline. " ON )
 OPTION( WITH_EDITOR_FLAG "Enables or disables the editor in the Fling Engine!" ON )
 OPTION( ENABLE_MULTICORE "ENABLE_MULTICORE will allow MSVC to use all cores by adding the /MP option" ON)
-FLING_Compiler_Flag( Fling_Enable_Test WITH_ENABLE_TEST "A test flag by ben" ON )
 
 # We can't have the editor without ImGUI!
 IF( NOT WITH_IMGUI_FLAG AND WITH_EDITOR_FLAG )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ message( STATUS "Cmake mod path: " ${CMAKE_MODULE_PATH} )
 include(FlingEngineInc)
 include(MSVC_PCH)
 include(FlingCompilerFlag)
+include (InstallRequiredSystemLibraries)
 
 set ( FLING_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" )
 
@@ -38,7 +39,6 @@ message( STATUS "WITH_IMGUI_FLAG=${WITH_IMGUI_FLAG}" )
 message( STATUS "DEFINE_SHIPPING=${DEFINE_SHIPPING}" )
 message( STATUS "ENABLE_MULTICORE=${ENABLE_MULTICORE}" )
 message( STATUS "FLING_ROOT_DIR=${FLING_ROOT_DIR}" )
-message( STATUS "Fling_Enable_Test=${Fling_Enable_Test}" )
 
 # set the flags to 0 or 1 respectively for ImGUI and the Editor
 IF( WITH_IMGUI_FLAG )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,27 @@ set( CMAKE_INSTALL_MESSAGE LAZY )   # Skips update to date messages
 
 project ( "FlingEngine" )
 
+# Generated folder used for Cmake generated files
+set( GENERATED_INC_FOLDER ${CMAKE_BINARY_DIR}/Generated )
+message( STATUS "Generated dir: ${GENERATED_INC_FOLDER}" )
+
+# Let us use our *.cmake files now
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
+message( STATUS "Cmake mod path: " ${CMAKE_MODULE_PATH} )
+
+# Include any .cmake macros here from the ./Cmake dir
+include(FlingEngineInc)
+include(MSVC_PCH)
+include(FlingCompilerFlag)
+
 set ( FLING_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" )
 
-# Option for seperate "shipping" config
-OPTION( DEFINE_SHIPPING "DEFINE_SHIPPING configuration will change asset paths to be relative." OFF ) # disabled by default
-
+# Option for the current build configuration. Note: going forward, we should use the FLING_Compiler_Flag macro
+OPTION( DEFINE_SHIPPING "DEFINE_SHIPPING configuration will change asset paths to be relative." OFF )
 OPTION( WITH_IMGUI_FLAG "WITH_IMGUI_FLAG will enable or disable the addition of IMGUI to the rendering pipeline. " ON )
 OPTION( WITH_EDITOR_FLAG "Enables or disables the editor in the Fling Engine!" ON )
-OPTION ( ENABLE_MULTICORE "ENABLE_MULTICORE will allow MSVC to use all cores by adding the /MP option" ON)
+OPTION( ENABLE_MULTICORE "ENABLE_MULTICORE will allow MSVC to use all cores by adding the /MP option" ON)
+FLING_Compiler_Flag( Fling_Enable_Test WITH_ENABLE_TEST "A test flag by ben" ON )
 
 # We can't have the editor without ImGUI!
 IF( NOT WITH_IMGUI_FLAG AND WITH_EDITOR_FLAG )
@@ -25,6 +38,8 @@ message( STATUS "WITH_EDITOR_FLAG=${WITH_EDITOR_FLAG}" )
 message( STATUS "WITH_IMGUI_FLAG=${WITH_IMGUI_FLAG}" )
 message( STATUS "DEFINE_SHIPPING=${DEFINE_SHIPPING}" )
 message( STATUS "ENABLE_MULTICORE=${ENABLE_MULTICORE}" )
+message( STATUS "FLING_ROOT_DIR=${FLING_ROOT_DIR}" )
+message( STATUS "Fling_Enable_Test=${Fling_Enable_Test}" )
 
 # set the flags to 0 or 1 respectively for ImGUI and the Editor
 IF( WITH_IMGUI_FLAG )
@@ -50,16 +65,6 @@ message( STATUS "-----------------------" )
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 set( CMAKE_CXX_EXTENSIONS OFF )
-
-# Generated folder used for Cmake generated files
-set( GENERATED_INC_FOLDER ${CMAKE_BINARY_DIR}/Generated )
-message( STATUS "Generated dir: ${GENERATED_INC_FOLDER}" )
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
-include(FlingEngineInc) # Could be in /tests/CMakeLists.txt
-include(MSVC_PCH) # Could be in /tests/CMakeLists.txt
-
-message( STATUS "Cmake mod path: " ${CMAKE_MODULE_PATH} )
 
 # Take care of warnings about strcpy
 if( MSVC )

--- a/FlingEngine/CMakeLists.txt
+++ b/FlingEngine/CMakeLists.txt
@@ -1,4 +1,5 @@
-project( "FlingEngine" )
+
+project ( "FlingEngine" VERSION 1.0 )
 
 #### Setup Git version numbers ######
 execute_process(
@@ -117,6 +118,14 @@ if( MSVC )
         source_group( "${_group_path}" FILES "${_source}" )
     endforeach()
 endif()
+
+################# Add dynamic module directories ###################
+# TODO: Can't we do this recursively or something like that??
+add_subdirectory(Foundation)
+# Link against the Foundation module
+set( LINK_LIBS ${LINK_LIBS} Foundation )
+
+#find_package(Foundation REQUIRED)
 
 ################# Add library and link ######################
 

--- a/FlingEngine/Core/src/Engine.cpp
+++ b/FlingEngine/Core/src/Engine.cpp
@@ -4,11 +4,14 @@
 #include "File.h"
 #include "VulkanApp.h"
 #include "Misc/CommandLine.h"
+#include "Foundation.h"
 
 namespace Fling
 {
     void Engine::Startup(int argc, char* argv[])
 	{	
+		const bool b = FoundationClass::RunFoundationFunction();
+
 		Random::Init();
 		Logger::Get().Init();
 		

--- a/FlingEngine/Foundation/CMakeLists.txt
+++ b/FlingEngine/Foundation/CMakeLists.txt
@@ -7,10 +7,6 @@ project("Foundation" VERSION 0.1)
 
 message(status "-- The foundation library is being configured!! -- ")
 
-include_directories(
-	inc
-)
-
 # Find any C++ files here
 file( GLOB_RECURSE foundation_source_list
     *.cpp* src/*.h* src/*.hpp* *.h* *.inl
@@ -26,7 +22,9 @@ if( MSVC )
     endforeach()
 endif()
 
-# the "Shared" part here means that the library target is a DLL
+# Libraries will produce a shared .dll file, and a .lib file that has the actual
+# linking interface. If a module doesn't export any symbols (i.e. __declspec(dllexport)), then it won't 
+# produce a .lib and VS will error when building the game target
 add_library ( ${PROJECT_NAME} SHARED ${foundation_source_list} )
 
 # I think fix the include paths?

--- a/FlingEngine/Foundation/CMakeLists.txt
+++ b/FlingEngine/Foundation/CMakeLists.txt
@@ -1,0 +1,42 @@
+# The Foundation target contains the core building blocks that Fling can use to make the Engine.
+# this shouldn't depend on any other Fling Engine targets to avoid circular build dependcies
+
+cmake_minimum_required (VERSION 3.11.0)
+
+project("Foundation" VERSION 0.1)
+
+message(status "-- The foundation library is being configured!! -- ")
+
+include_directories(
+	inc
+)
+
+# Find any C++ files here
+file( GLOB_RECURSE foundation_source_list
+    *.cpp* src/*.h* src/*.hpp* *.h* *.inl
+)
+
+# Make VS look ok
+if( MSVC )
+    foreach( _source IN ITEMS ${foundation_source_list} )
+    	get_filename_component( _source_path "${_source}" PATH )
+        string( REPLACE "${CMAKE_SOURCE_DIR}" "" _group_path "${_source_path}" )
+        string( REPLACE "/" "\\" _group_path "${_group_path}" )
+        source_group( "${_group_path}" FILES "${_source}" )
+    endforeach()
+endif()
+
+# the "Shared" part here means that the library target is a DLL
+add_library ( ${PROJECT_NAME} SHARED ${foundation_source_list} )
+
+# I think fix the include paths?
+target_include_directories(${PROJECT_NAME} PUBLIC inc)
+target_include_directories(${PROJECT_NAME} PRIVATE src)
+
+# set the version of this library
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
+
+#target_include_directories (${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${SPIRV_CROSS_INCLUDE_DIR})
+
+# If we need to link against anything, do so here
+# target_link_libraries( ${PROJECT_NAME} LINK_PUBLIC ${LINK_LIBS} )

--- a/FlingEngine/Foundation/inc/Foundation.h
+++ b/FlingEngine/Foundation/inc/Foundation.h
@@ -1,0 +1,8 @@
+#pragma once
+
+class FoundationClass
+{
+public:
+    static bool RunFoundationFunction();
+
+};

--- a/FlingEngine/Foundation/inc/Foundation.h
+++ b/FlingEngine/Foundation/inc/Foundation.h
@@ -1,6 +1,8 @@
 #pragma once
 
-class FoundationClass
+#include "FoundationAPI.h"
+
+class FOUNDATION_API FoundationClass
 {
 public:
     static bool RunFoundationFunction();

--- a/FlingEngine/Foundation/inc/FoundationAPI.h
+++ b/FlingEngine/Foundation/inc/FoundationAPI.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// TODO: Per-platform definitions here
+#ifndef FOUNDATION_API
+#		define FOUNDATION_API        __declspec(dllexport) 
+#       define FLING_EXTERN      
+#else					        // Not exporting function
+#		define FOUNDATION_API        
+#       define FOUNDATION_EXTERN        extern
+#endif

--- a/FlingEngine/Foundation/src/Foundation.cpp
+++ b/FlingEngine/Foundation/src/Foundation.cpp
@@ -1,0 +1,6 @@
+#include "Foundation.h"
+
+bool FoundationClass::RunFoundationFunction()
+{
+    return true;
+}

--- a/FlingTests/CMakeLists.txt
+++ b/FlingTests/CMakeLists.txt
@@ -19,6 +19,7 @@ set ( LINK_LIBS
     glfw ${GLFW_LIBRARIES}
 	Catch
 	"FlingEngine"
+    Foundation
 )
 
 # link pthread if we need to

--- a/Sandbox/CMakeLists.txt
+++ b/Sandbox/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 
 set ( LINK_LIBS
 	"FlingEngine"
+    Foundation
 )
 
 # link pthread if we need to


### PR DESCRIPTION
## Feature/Issue
Created a Foundation module that is linked. Here we can start to separate out the logic of the engine into different DLL's and .lib files instead of having everything in one. This will make it way easier to keep things sep

## Implementation/Solution
using Cmake we can create shared library targets now and link them where needed

## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
