### PR TITLE
Add -WaitForDebugger command line flag

### DIFF
--- a/FlingEngine/Core/inc/Engine.h
+++ b/FlingEngine/Core/inc/Engine.h
@@ -9,6 +9,7 @@
 #include "World.h"
 #include <nlohmann/json.hpp>
 #include <entt/entity/registry.hpp>
+#include <csignal>
 
 #include "MovingAverage.hpp"
 #include "Stats.h"
@@ -19,6 +20,20 @@
 #include "BaseEditor.h"
 
 #endif	// WITH_EDITOR
+
+/**
+ * Triggers a breakpoint at the call site, halting execution if a debugger is attached.
+ * Works across compilers/platforms so callers don't need their own #ifdef ladder.
+ */
+#if defined( _MSC_VER )
+	#define F_DEBUG_BREAK() __debugbreak()
+#elif defined( __clang__ )
+	#define F_DEBUG_BREAK() __builtin_debugtrap()
+#elif defined( __GNUC__ )
+	#define F_DEBUG_BREAK() raise( SIGTRAP )
+#else
+	#define F_DEBUG_BREAK()
+#endif
 
 namespace Fling
 {

--- a/FlingEngine/Core/src/Engine.cpp
+++ b/FlingEngine/Core/src/Engine.cpp
@@ -20,6 +20,12 @@ namespace Fling
 
 		FlingConfig::Get().Init();
 
+		if (CommandLine::Get().GetValueAs<bool>("WaitForDebugger", false))
+		{
+			F_LOG_TRACE("-WaitForDebugger was set, breaking into the debugger now");
+			F_DEBUG_BREAK();
+		}
+
 		ResourceManager::Get().Init();
 		Timing::Get().Init();        
 		Input::Init();


### PR DESCRIPTION
## Summary
- Closes #178 — adds a `-WaitForDebugger=true` command line flag (à la Unreal's `-waitfordebugger`).
- Adds a cross-platform `F_DEBUG_BREAK()` macro in `Engine.h` (MSVC `__debugbreak()`, Clang `__builtin_debugtrap()`, GCC `raise(SIGTRAP)`), so callers don't need their own compiler `#ifdef` ladder.
- Wires the flag into `Engine::Startup`, right after `FlingConfig::Get().Init()`, using the `CommandLine`/`GetValueAs<bool>` API from #179.

## Test plan
- [x] Verified under `gdb`: `Sandbox -WaitForDebugger=true` hits `SIGTRAP` exactly at the intended line in `Engine::Startup`; running without the flag proceeds straight through with no trap.
- Not covered by the automated `FlingTests` suite intentionally — triggering the trap with no debugger attached would abort the test process in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)