### PR TITLE
Add MSYS2 MINGW64 CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
             os: windows-2022
             compiler: msvc
             build_type: Release
+          - name: Windows MSYS2 MinGW64 Release
+            os: windows-2022
+            compiler: mingw
+            build_type: Release
 
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +60,7 @@ jobs:
             libvulkan-dev
 
       - name: Install Vulkan SDK (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.compiler != 'mingw'
         uses: jakoch/install-vulkan-sdk-action@v1
         with:
           vulkan_version: 1.4.357.0
@@ -64,8 +68,21 @@ jobs:
           cache: true
           stripdown: true
 
+      - name: Setup MSYS2 (MinGW64)
+        if: matrix.compiler == 'mingw'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-vulkan-devel
+
       # ---------- Catch2 (needed by find_package(Catch2 3 REQUIRED)) ----------
       - name: Build and install Catch2
+        if: matrix.compiler != 'mingw'
         shell: bash
         run: |
           cmake -S external/Catch2 -B external/Catch2/build \
@@ -75,6 +92,18 @@ jobs:
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
             -DBUILD_TESTING=OFF
           cmake --build external/Catch2/build --config ${{ matrix.build_type }} --target install
+
+      - name: Build and install Catch2 (MinGW64)
+        if: matrix.compiler == 'mingw'
+        shell: msys2 {0}
+        run: |
+          cmake -S external/Catch2 -B external/Catch2/build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/.deps" \
+            -DCMAKE_CXX_STANDARD=20 \
+            -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+            -DBUILD_TESTING=OFF
+          cmake --build external/Catch2/build --target install
 
       # ---------- configure + build ----------
       - name: Configure (Linux)
@@ -89,15 +118,30 @@ jobs:
             -DCMAKE_PREFIX_PATH="${{ github.workspace }}/.deps"
 
       - name: Configure (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.compiler != 'mingw'
         run: |
           cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
             -DDEFINE_SHIPPING=OFF `
             -DENABLE_MULTICORE=ON `
             -DCMAKE_PREFIX_PATH="${{ github.workspace }}/.deps"
 
+      - name: Configure (MinGW64)
+        if: matrix.compiler == 'mingw'
+        shell: msys2 {0}
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DDEFINE_SHIPPING=OFF \
+            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/.deps"
+
       - name: Build
+        if: matrix.compiler != 'mingw'
         run: cmake --build build --config ${{ matrix.build_type }} --parallel
+
+      - name: Build (MinGW64)
+        if: matrix.compiler == 'mingw'
+        shell: msys2 {0}
+        run: cmake --build build --parallel
 
       # ---------- run tests ----------
       - name: Run FlingTests (Linux)
@@ -107,8 +151,15 @@ jobs:
           ./build/FlingTests/bin/FlingTests
 
       - name: Run FlingTests (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.compiler != 'mingw'
         shell: cmd
         run: |
           if not exist Logs mkdir Logs
           build\FlingTests\bin\${{ matrix.build_type }}\FlingTests.exe
+
+      - name: Run FlingTests (MinGW64)
+        if: matrix.compiler == 'mingw'
+        shell: msys2 {0}
+        run: |
+          mkdir -p Logs
+          ./build/FlingTests/bin/FlingTests.exe

--- a/FlingEngine/CMakeLists.txt
+++ b/FlingEngine/CMakeLists.txt
@@ -82,16 +82,20 @@ if ( NOT WIN32 )
     message( STATUS "Added pthread!" )
 endif()
 
-# We need to link the std::filesystem on clang/GNU, but the windows version of 
-# Clang doesn't have this lib
+# We need to link the std::filesystem on clang/GNU, but the windows version of
+# Clang doesn't have this lib. GCC >= 9 folds std::filesystem into libstdc++ itself,
+# so the standalone stdc++fs archive (which MinGW-w64/MSYS2 toolchains don't ship) is
+# only needed on older GCC.
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     if(NOT WIN32)
     set( LINK_LIBS ${LINK_LIBS} stdc++fs )
         message( STATUS "Added filesytem link (Clang)!" )
     endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set( LINK_LIBS ${LINK_LIBS} stdc++fs )
-    message( STATUS "Added filesytem link (GNU)!" )
+    if( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0 )
+        set( LINK_LIBS ${LINK_LIBS} stdc++fs )
+        message( STATUS "Added filesytem link (GNU)!" )
+    endif()
 endif()
 
 message( STATUS "LINK_LIBS is : " ${LINK_LIBS} )

--- a/FlingEngine/Core/inc/Engine.h
+++ b/FlingEngine/Core/inc/Engine.h
@@ -29,6 +29,9 @@
 	#define F_DEBUG_BREAK() __debugbreak()
 #elif defined( __clang__ )
 	#define F_DEBUG_BREAK() __builtin_debugtrap()
+#elif defined( __MINGW32__ )
+	// MinGW-w64 targets Windows, which has no SIGTRAP to raise()
+	#define F_DEBUG_BREAK() asm("int $3")
 #elif defined( __GNUC__ )
 	#define F_DEBUG_BREAK() raise( SIGTRAP )
 #else


### PR DESCRIPTION
## Summary
- Adds a Windows MSYS2 MinGW64 build+test job to the CI matrix (uses pacman's `mingw-w64-x86_64-vulkan-devel` instead of the LunarG SDK).
- Guards the `-lstdc++fs` link for GNU to GCC < 9, since GCC >= 9 (including MSYS2's toolchain) folds `std::filesystem` into libstdc++ and doesn't ship a standalone `stdc++fs` archive.

Opened as a draft to validate the new CI job actually builds/passes on GitHub's Windows runners before merging.

Addresses #175.

## Test plan
- [ ] CI green across all matrix entries, including the new "Windows MSYS2 MinGW64 Release" job
- [ ] FlingTests passes under the MinGW64 build

🤖 Generated with [Claude Code](https://claude.com/claude-code)