### PR TITLE
Fix FlingTests config loading under DEFINE_SHIPPING.

### DIFF
--- a/FlingEngine/Resources/src/FlingPaths.cpp
+++ b/FlingEngine/Resources/src/FlingPaths.cpp
@@ -34,11 +34,13 @@ namespace Fling
 
     void FlingPaths::GetCurrentWorkingDir(char* t_OutBuf, size_t t_BufSize)
     {
+        // Normalize CWD to the directory that contains this executable.
+        // Shipping builds use relative paths (Config/, Assets/, Logs/), so
+        // loading must not depend on whichever directory the process was
+        // launched from (IDE vs shell vs CI).
 #if FLING_WINDOWS
         {
-            // Get the real, full path to this executable, end the string before
-            // the filename itself and then set that as the current directory
-            GetModuleFileName(0, t_OutBuf, t_BufSize);
+            GetModuleFileName(0, t_OutBuf, static_cast<DWORD>(t_BufSize));
             char* lastSlash = strrchr(t_OutBuf, '\\');
             if (lastSlash)
             {
@@ -48,19 +50,27 @@ namespace Fling
         }
 #elif FLING_LINUX
         {
-            if (getcwd(t_OutBuf, t_BufSize) != nullptr) 
+            const ssize_t Len = readlink("/proc/self/exe", t_OutBuf, t_BufSize - 1);
+            if (Len == -1)
             {
-                F_LOG_TRACE("Current working dir: {}\n", t_OutBuf);
-            }
-            else 
-            {
-                F_LOG_FATAL("getcwd() error");
+                F_LOG_FATAL("readlink(/proc/self/exe) error");
+                return;
             }
 
-            if (chdir(t_OutBuf) == -1) 
+            t_OutBuf[Len] = '\0';
+            char* lastSlash = strrchr(t_OutBuf, '/');
+            if (lastSlash)
             {
-                F_LOG_FATAL("chdir() error :");
+                *lastSlash = 0;
             }
+
+            if (chdir(t_OutBuf) == -1)
+            {
+                F_LOG_FATAL("chdir() error");
+                return;
+            }
+
+            F_LOG_TRACE("Current working dir: {}", t_OutBuf);
         }
 #endif	// FLING_LINUX
     }

--- a/FlingTests/CMakeLists.txt
+++ b/FlingTests/CMakeLists.txt
@@ -61,3 +61,13 @@ add_executable( ${PROJECT_NAME} ${_source_list} )
 
 # Link Catch2 and everything else
 target_link_libraries( ${PROJECT_NAME} LINK_PUBLIC ${LINK_LIBS} )
+
+# Shipping builds resolve EngineConfigDir() to a relative "Config" path, and
+# ResourceManager::Init() chdirs to the executable directory. Keep TestConf.ini
+# next to the binary so FlingTests pass regardless of launch CWD.
+add_custom_command( TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${FLING_ROOT_DIR}/Config"
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/Config"
+    COMMENT "Copying Config next to ${PROJECT_NAME}"
+)

--- a/FlingTests/src/ResourceTests.cpp
+++ b/FlingTests/src/ResourceTests.cpp
@@ -14,15 +14,13 @@ TEST_CASE("Engine Config File", "[resource]")
     using namespace Fling;
     // Logger HAS to be initalized first
     Logger::Get().Init();
+    // Sets CWD to the executable directory so relative shipping paths resolve
     ResourceManager::Get().Init();
     FlingConfig::Get().Init();
 
-    SECTION("Valid Config")
-    {
-        // Load a test config
-        bool ConfigLoaded = FlingConfig::Get().LoadConfigFile(FlingPaths::EngineConfigDir() + "/TestConf.ini");
-        REQUIRE(ConfigLoaded);
-    }
+    // Load once for all sections (Catch re-runs this block per SECTION)
+    bool ConfigLoaded = FlingConfig::Get().LoadConfigFile(FlingPaths::EngineConfigDir() + "/TestConf.ini");
+    REQUIRE(ConfigLoaded);
 
     SECTION("Read False Bool")
     {


### PR DESCRIPTION
Make Linux chdir to the executable directory like Windows, copy Config next to the test binary, and load TestConf.ini before Catch sections so relative shipping paths work from any launch CWD.

## Feature/Issue
Fix tests failing on linux

## Implementation/Solution
correct current working dir (CWD) impl when getting the active director

## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
