### PR TITLE
Install Catch2 locally in Init.sh so it no longer requires sudo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "external/Catch2"]
 	path = external/Catch2
 	url = https://github.com/flingengine/Catch2.git
+	ignore = dirty
 [submodule "external/glm"]
 	path = external/glm
 	url = https://github.com/flingengine/glm.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ include (InstallRequiredSystemLibraries)
 
 set ( FLING_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" )
 
+# Catch2 is installed locally by Init.sh (not system-wide) so find_package can locate it without sudo
+list( APPEND CMAKE_PREFIX_PATH "${FLING_ROOT_DIR}/external/Catch2/install" )
+
 # Option for the current build configuration. Note: going forward, we should use the FLING_Compiler_Flag macro
 OPTION( DEFINE_SHIPPING "DEFINE_SHIPPING configuration will change asset paths to be relative." OFF )
 OPTION( WITH_IMGUI_FLAG "WITH_IMGUI_FLAG will enable or disable the addition of IMGUI to the rendering pipeline. " ON )

--- a/Init.sh
+++ b/Init.sh
@@ -7,10 +7,10 @@ echo   =============================================================
 echo Initalizing submodules...
 git submodule update --init --recursive
 
-# Install Catch2 so that CMake can find it
+# Install Catch2 so that CMake can find it (installed locally so no sudo is needed)
 echo Installing Catch2 testing library...
-cmake ./external/Catch2 -B ./external/Catch2/build
-sudo make install --directory=./external/Catch2/build -j$(nproc)
+cmake ./external/Catch2 -B ./external/Catch2/build -DCMAKE_INSTALL_PREFIX=./external/Catch2/install
+make install --directory=./external/Catch2/build -j$(nproc)
 
 # Run cmake!
 echo Running CMake 


### PR DESCRIPTION
Make catch2 installed locally so you dont need sudo when running init.sh, and ignore its intermediate files. 


## Tests
 - [X] Have you reviewed your own code for quality?
 - [X] Did you the `Sandbox` game project and get the expected results? 
 - [X] Did you run the `FlingTest` suite and ensure that there are no regressions? 
