### PR TITLE
Update spdlog submodule to v1.17.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ if( MSVC )
         SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
         SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
     endif()
+
+    # spdlog 1.17+ bundles fmt v12, which requires UTF-8 source encoding on MSVC.
+    # See https://github.com/fmtlib/fmt/pull/4159
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8")
 # GCC
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 

--- a/FlingEngine/Graphics/inc/GraphicsHelpers.h
+++ b/FlingEngine/Graphics/inc/GraphicsHelpers.h
@@ -11,7 +11,7 @@
 	VkResult res = (f);																\
 	if (res != VK_SUCCESS)															\
 	{																				\
-		F_LOG_ERROR("VkResult is {} in {} at line {}", res, __FILE__, __LINE__);	\
+		F_LOG_ERROR("VkResult is {} in {} at line {}", static_cast<int>(res), __FILE__, __LINE__);	\
 		assert(res == VK_SUCCESS);													\
 	}																				\
 }


### PR DESCRIPTION
## Summary
- The `flingengine/spdlog` fork's `v1.x` branch was already synced with upstream `gabime/spdlog`, but was missing the release tags after `v1.3.1`. Pushed the missing tags (`v1.4.0`-`v1.17.0`) to the fork so it has proper release references.
- Bumped the `external/spdlog` submodule pin from `v1.3.1` to `v1.17.0` (latest stable upstream release).
- spdlog v1.17.0 bundles fmt v12, which is stricter about formatting arbitrary enums. `VK_CHECK_RESULT` in `GraphicsHelpers.h` was logging a raw `VkResult`, which no longer compiles. Fixed by casting to `int` at that call site — the only place in the codebase that logs a `VkResult` directly.

## Test plan
- [x] `cmake . -B build -DCMAKE_BUILD_TYPE=Debug -DDEFINE_SHIPPING=OFF && cmake --build build -j$(nproc)` — builds clean
- [x] `./build/FlingTests/bin/FlingTests` — all tests pass (172 assertions, 17 test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)